### PR TITLE
feat(SebmGoogleMapMarker): Allow usage of complex icon objects

### DIFF
--- a/src/core/directives/google-map-marker.ts
+++ b/src/core/directives/google-map-marker.ts
@@ -38,7 +38,7 @@ let markerId = 0;
   selector: 'sebm-google-map-marker',
   inputs: [
     'latitude', 'longitude', 'title', 'label', 'draggable: markerDraggable', 'iconUrl',
-    'openInfoWindow', 'fitBounds', 'opacity', 'visible'
+    'openInfoWindow', 'fitBounds', 'opacity', 'visible', 'complexIcon'
   ],
   outputs: ['markerClick', 'dragEnd']
 })
@@ -79,6 +79,13 @@ export class SebmGoogleMapMarker implements OnDestroy, OnChanges, AfterContentIn
   visible: boolean = true;
 
   /**
+   * Icon structure (as specified here
+   * https://developers.google.com/maps/documentation/javascript/3.exp/reference#Icon
+   * https://developers.google.com/maps/documentation/javascript/3.exp/reference#Symbol)
+   */
+  complexIcon: mapTypes.MarkerIcon|mapTypes.MarkerSymbol = {};
+
+  /**
    * Whether to automatically open the child info window when the marker is clicked.
    */
   openInfoWindow: boolean = true;
@@ -106,6 +113,19 @@ export class SebmGoogleMapMarker implements OnDestroy, OnChanges, AfterContentIn
 
   constructor(private _markerManager: MarkerManager) { this._id = (markerId++).toString(); }
 
+  /**
+   * Accessor to return either the complexIcon object or just the iconUrl
+   */
+  public get icon(): mapTypes.MarkerIcon|mapTypes.MarkerSymbol {
+    let marker = Object.assign({}, this.complexIcon);
+
+    if (this.iconUrl !== undefined && this.iconUrl.length !== 0) {
+      marker.url = this.iconUrl;
+    }
+
+    return marker;
+  }
+
   /* @internal */
   ngAfterContentInit() {
     if (this._infoWindow != null) {
@@ -124,6 +144,7 @@ export class SebmGoogleMapMarker implements OnDestroy, OnChanges, AfterContentIn
       this._addEventListeners();
       return;
     }
+
     if (changes['latitude'] || changes['longitude']) {
       this._markerManager.updateMarkerPosition(this);
     }
@@ -137,6 +158,9 @@ export class SebmGoogleMapMarker implements OnDestroy, OnChanges, AfterContentIn
       this._markerManager.updateDraggable(this);
     }
     if (changes['iconUrl']) {
+      this._markerManager.updateIcon(this);
+    }
+    if (changes['complexIcon']) {
       this._markerManager.updateIcon(this);
     }
     if (changes['opacity']) {

--- a/src/core/services/google-maps-types.ts
+++ b/src/core/services/google-maps-types.ts
@@ -26,7 +26,7 @@ export interface Marker extends MVCObject {
   setTitle(title: string): void;
   setLabel(label: string|MarkerLabel): void;
   setDraggable(draggable: boolean): void;
-  setIcon(icon: string): void;
+  setIcon(icon: string|MarkerIcon|MarkerSymbol): void;
   setOpacity(opacity: number): void;
   setVisible(visible: boolean): void;
   getLabel(): MarkerLabel;
@@ -38,7 +38,7 @@ export interface MarkerOptions {
   map?: GoogleMap;
   label?: string|MarkerLabel;
   draggable?: boolean;
-  icon?: string;
+  icon?: string|MarkerIcon|MarkerSymbol;
   opacity?: number;
   visible?: boolean;
 }
@@ -49,6 +49,28 @@ export interface MarkerLabel {
   fontSize: string;
   fontWeight: string;
   text: string;
+}
+
+export interface MarkerIcon {
+  anchor?: Point;
+  labelOrigin?: Point;
+  origin?: Point;
+  scaledSize?: Size;
+  size?: Size;
+  url?: string;
+}
+
+export interface MarkerSymbol {
+  anchor?: Point;
+  fillColor?: string;
+  fillOpacity?: number;
+  labelOrigin?: Point;
+  path: string;
+  rotation?: number;
+  scale?: number;
+  strokeColor?: string;
+  strokeOpacity?: number;
+  strokeWeight?: number;
 }
 
 export interface Circle extends MVCObject {
@@ -190,4 +212,9 @@ export interface InfoWindowOptions {
   pixelOffset?: Size;
   position?: LatLng|LatLngLiteral;
   zIndex?: number;
+}
+
+export interface Point {
+  x: number;
+  y: number;
 }

--- a/src/core/services/managers/marker-manager.ts
+++ b/src/core/services/managers/marker-manager.ts
@@ -46,7 +46,7 @@ export class MarkerManager {
   }
 
   updateIcon(marker: SebmGoogleMapMarker): Promise<void> {
-    return this._markers.get(marker).then((m: Marker) => m.setIcon(marker.iconUrl));
+    return this._markers.get(marker).then((m: Marker) => { m.setIcon(marker.icon); });
   }
 
   updateOpacity(marker: SebmGoogleMapMarker): Promise<void> {
@@ -62,9 +62,9 @@ export class MarkerManager {
       position: {lat: marker.latitude, lng: marker.longitude},
       label: marker.label,
       draggable: marker.draggable,
-      icon: marker.iconUrl,
       opacity: marker.opacity,
-      visible: marker.visible
+      visible: marker.visible,
+      icon: marker.icon
     });
     this._markers.set(marker, markerPromise);
   }

--- a/test/services/managers/marker-manager.spec.ts
+++ b/test/services/managers/marker-manager.spec.ts
@@ -33,7 +33,7 @@ export function main() {
                  position: {lat: 34.4, lng: 22.3},
                  label: 'A',
                  draggable: false,
-                 icon: undefined,
+                 icon: {},
                  opacity: 1,
                  visible: true
                });
@@ -60,7 +60,7 @@ export function main() {
     });
 
     describe('set marker icon', () => {
-      it('should update that marker via setIcon method when the markerUrl changes',
+      it('should update that marker via setIcon method when the iconUrl changes',
          async(inject(
              [MarkerManager, GoogleMapsAPIWrapper],
              (markerManager: MarkerManager, apiWrapper: GoogleMapsAPIWrapper) => {
@@ -77,14 +77,14 @@ export function main() {
                  position: {lat: 34.4, lng: 22.3},
                  label: 'A',
                  draggable: false,
-                 icon: undefined,
+                 icon: {},
                  opacity: 1,
                  visible: true
                });
                const iconUrl = 'http://angular-maps.com/icon.png';
-               newMarker.iconUrl = iconUrl;
+               newMarker.complexIcon.url = iconUrl;
                return markerManager.updateIcon(newMarker).then(
-                   () => { expect(markerInstance.setIcon).toHaveBeenCalledWith(iconUrl); });
+                   () => { expect(markerInstance.setIcon).toHaveBeenCalledWith({url: iconUrl}); });
              })));
     });
 
@@ -107,7 +107,7 @@ export function main() {
                  position: {lat: 34.4, lng: 22.3},
                  label: 'A',
                  draggable: false,
-                 icon: undefined,
+                 icon: {},
                  visible: true,
                  opacity: 1
                });
@@ -138,7 +138,7 @@ export function main() {
                  position: {lat: 34.4, lng: 22.3},
                  label: 'A',
                  draggable: false,
-                 icon: undefined,
+                 icon: {},
                  visible: false,
                  opacity: 1
                });


### PR DESCRIPTION
It would be nice to be able to use objects like google.maps.Icon or google.maps.Symbol to set an icon (for instance to be able to specify a svg with scaling enabled)
