### PR TITLE
fix(GoogleMapsAPIWrapper): #770 circle strokeWeight throws error

### DIFF
--- a/src/core/services/google-maps-api-wrapper.ts
+++ b/src/core/services/google-maps-api-wrapper.ts
@@ -57,6 +57,11 @@ export class GoogleMapsAPIWrapper {
   createCircle(options: mapTypes.CircleOptions): Promise<mapTypes.Circle> {
     return this._map.then((map: mapTypes.GoogleMap) => {
       options.map = map;
+
+      if (typeof options.strokePosition === 'string') {
+        options.strokePosition = google.maps.StrokePosition[options.strokePosition];
+      }
+
       return new google.maps.Circle(options);
     });
   }


### PR DESCRIPTION
When setting strokeWeight property google maps throws an error because the strokePosition option is set with an invalid value