### PR TITLE
auto-fitBounds - WIP

### DIFF
--- a/src/core/directives/map.ts
+++ b/src/core/directives/map.ts
@@ -13,6 +13,7 @@ import {PolygonManager} from '../services/managers/polygon-manager';
 import {PolylineManager} from '../services/managers/polyline-manager';
 import {KmlLayerManager} from './../services/managers/kml-layer-manager';
 import {DataLayerManager} from './../services/managers/data-layer-manager';
+import {FitBoundsService} from './../services/fitBounds.service';
 
 /**
  * AgmMap renders a Google Map.
@@ -41,7 +42,7 @@ import {DataLayerManager} from './../services/managers/data-layer-manager';
   selector: 'agm-map',
   providers: [
     GoogleMapsAPIWrapper, MarkerManager, InfoWindowManager, CircleManager, PolylineManager,
-    PolygonManager, KmlLayerManager, DataLayerManager
+    PolygonManager, KmlLayerManager, DataLayerManager, FitBoundsService
   ],
   inputs: [
     'longitude', 'latitude', 'zoom', 'minZoom', 'maxZoom', 'draggable: mapDraggable',
@@ -189,7 +190,7 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
   /**
    * Sets the viewport to contain the given bounds.
    */
-  fitBounds: LatLngBoundsLiteral|LatLngBounds = null;
+  fitBounds: LatLngBoundsLiteral|LatLngBounds|boolean = null;
 
   /**
    * The initial enabled/disabled state of the Scale control. This is disabled by default.
@@ -254,6 +255,8 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
 
   private _observableSubscriptions: Subscription[] = [];
 
+  private _fitBoundsSubscription: Subscription;
+
   /**
    * This event emitter gets emitted when the user clicks on the map (but not when they click on a
    * marker or infoWindow).
@@ -292,7 +295,10 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
    */
   zoomChange: EventEmitter<number> = new EventEmitter<number>();
 
-  constructor(private _elem: ElementRef, private _mapsWrapper: GoogleMapsAPIWrapper) {}
+  constructor(
+    private _elem: ElementRef,
+    private _mapsWrapper: GoogleMapsAPIWrapper,
+    private _fitBoundsService: FitBoundsService) {}
 
   /** @internal */
   ngOnInit() {
@@ -402,11 +408,37 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
   }
 
   private _fitBounds() {
-    if (this.usePanning) {
-      this._mapsWrapper.panToBounds(this.fitBounds);
+    if (this.fitBounds == null) {
       return;
     }
-    this._mapsWrapper.fitBounds(this.fitBounds);
+    if (typeof this.fitBounds !== 'boolean') {
+      if (this.usePanning) {
+        this._mapsWrapper.panToBounds(this.fitBounds);
+        return;
+      }
+      this._mapsWrapper.fitBounds(this.fitBounds);
+      return;
+    }
+
+    if (this.fitBounds === false && this._fitBoundsSubscription != null) {
+      // unbsubscribe to fitBounds updates
+      this._fitBoundsSubscription.unsubscribe();
+      this._fitBoundsSubscription = null;
+    } else if (this._fitBoundsSubscription == null) {
+      console.log('subscribe!');
+      this._fitBoundsSubscription = this._fitBoundsService.getBounds().subscribe((bounds) => {
+        console.log(bounds.toJSON());
+        if (this.fitBounds == null || bounds == null) {
+          return;
+        }
+        if (this.usePanning) {
+          this._mapsWrapper.panToBounds(bounds);
+          return;
+        }
+        this._mapsWrapper.fitBounds(bounds);
+      });
+    }
+
   }
 
   private _handleMapCenterChange() {

--- a/src/core/directives/marker.ts
+++ b/src/core/directives/marker.ts
@@ -37,9 +37,9 @@ let markerId = 0;
   selector: 'agm-marker',
   inputs: [
     'latitude', 'longitude', 'title', 'label', 'draggable: markerDraggable', 'iconUrl',
-    'openInfoWindow', 'opacity', 'visible', 'zIndex'
+    'openInfoWindow', 'opacity', 'visible', 'zIndex', 'fitBounds'
   ],
-  outputs: ['markerClick', 'dragEnd', 'mouseOver', 'mouseOut']
+  outputs: ['markerClick', 'dragEnd', 'mouseOver', 'mouseOut'],
 })
 export class AgmMarker implements OnDestroy, OnChanges, AfterContentInit {
   /**
@@ -96,6 +96,11 @@ export class AgmMarker implements OnDestroy, OnChanges, AfterContentInit {
   zIndex: number = 1;
 
   /**
+   * Fit to bounds? Defaults to true.
+   */
+  fitBounds: boolean = true;
+
+  /**
    * This event emitter gets emitted when the user clicks on the marker.
    */
   markerClick: EventEmitter<void> = new EventEmitter<void>();
@@ -124,7 +129,7 @@ export class AgmMarker implements OnDestroy, OnChanges, AfterContentInit {
   private _id: string;
   private _observableSubscriptions: Subscription[] = [];
 
-  constructor(private _markerManager: MarkerManager) { this._id = (markerId++).toString(); }
+  constructor(private _markerManager: MarkerManager, ) { this._id = (markerId++).toString(); }
 
   /* @internal */
   ngAfterContentInit() {
@@ -154,6 +159,9 @@ export class AgmMarker implements OnDestroy, OnChanges, AfterContentInit {
     }
     if (changes['latitude'] || changes['longitude']) {
       this._markerManager.updateMarkerPosition(this);
+    }
+    if (changes['fitBounds']) {
+      this._markerManager.updateBoundsOptions(this);
     }
     if (changes['title']) {
       this._markerManager.updateTitle(this);

--- a/src/core/services.ts
+++ b/src/core/services.ts
@@ -9,3 +9,4 @@ export {DataLayerManager} from './services/managers/data-layer-manager';
 export {GoogleMapsScriptProtocol, LAZY_MAPS_API_CONFIG, LazyMapsAPILoader, LazyMapsAPILoaderConfigLiteral} from './services/maps-api-loader/lazy-maps-api-loader';
 export {MapsAPILoader} from './services/maps-api-loader/maps-api-loader';
 export {NoOpMapsAPILoader} from './services/maps-api-loader/noop-maps-api-loader';
+export {FitBoundsService} from './services/fitBounds.service';

--- a/src/core/services/fitBounds.service.ts
+++ b/src/core/services/fitBounds.service.ts
@@ -1,0 +1,58 @@
+import {MapsAPILoader} from './maps-api-loader/maps-api-loader';
+import {LatLngLiteral, LatLngBounds, LatLng} from './google-maps-types';
+import {Observable} from 'rxjs/Observable';
+import {Injectable} from '@angular/core';
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+import 'rxjs/add/operator/debounce';
+import 'rxjs/add/operator/skipWhile';
+import 'rxjs/add/operator/mergeMap';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/distinctUntilChanged';
+import 'rxjs/add/observable/timer';
+import 'rxjs/add/observable/fromPromise';
+
+declare var google: any;
+
+@Injectable()
+export class FitBoundsService {
+  private _boundsSubject: BehaviorSubject<void> = new BehaviorSubject<void>(null);
+
+  /** @internal */
+  _boundsChangeDebounceTime: number = 200;
+
+  private _boundsResult: Map<any, LatLng|LatLngLiteral> = new Map();
+  private _boundsObservable: Observable<LatLngBounds>;
+
+  private _emitPaused: boolean = false;
+
+  constructor(loader: MapsAPILoader) {
+    this._boundsObservable = this._boundsSubject
+      .skipWhile(() => this._emitPaused)
+      .mergeMap(() => Observable.fromPromise(loader.load()))
+      .debounce(() => Observable.timer(this._boundsChangeDebounceTime))
+      .map(() => {
+        console.log('MAP');
+        const bounds = (new google.maps.LatLngBounds() as LatLngBounds);
+        this._boundsResult.forEach((b) => bounds.extend(b));
+        this._boundsResult.forEach((b) => console.log(b.lat, b.lng));
+        return bounds;
+      })
+      .distinctUntilChanged((v1: LatLngBounds, v2: LatLngBounds) => {
+        return v1.toString() === v2.toString();
+      });
+  }
+
+  addToBoundsResult(token: any, latLng: LatLng|LatLngLiteral): void {
+    this._boundsResult.set(token, latLng);
+    this._boundsSubject.next(null);
+  }
+
+  removeFromBoundsResult(token: any): void {
+    this._boundsResult.delete(token);
+    this._boundsSubject.next(null);
+  }
+
+  getBounds(): Observable<LatLngBounds|null> {
+    return this._boundsObservable;
+  }
+}

--- a/src/core/services/google-maps-types.ts
+++ b/src/core/services/google-maps-types.ts
@@ -91,7 +91,7 @@ export interface CircleOptions {
 export interface LatLngBounds {
   contains(latLng: LatLng): boolean;
   equals(other: LatLngBounds|LatLngBoundsLiteral): boolean;
-  extend(point: LatLng): void;
+  extend(point: LatLng|LatLngLiteral): void;
   getCenter(): LatLng;
   getNorthEast(): LatLng;
   getSouthWest(): LatLng;


### PR DESCRIPTION
**This is a WIP Pull request!**

This adds a new service named FitBoundsService. For every `AgmMap` component, a new instance gets created. The service computes the `LatLngBounds` for all given elements of the map.
The idea is that all core and custom child components of `AgmMap` inject that service to add or remove itself from the bounds. The should also provide a new Input named `fitBounds` (is the name a good idea?) to give the user the option to remove the element from the bounds. The default value of these fitBounds inputs should be true.

The LatLngBounds of the FitBoundsService are exposed as an Observable. The `AgmMap` component subscribes to this observable:

To enable auto-fitBounds, you have to set the fitBounds input to true:

```html
<agm-map [fitBounds]="true">
  <agm-marker [latitude]="33" [longitude]="40"></agm-marker>
  <agm-marker [latitude]="33" [longitude]="40" [fitBounds]="false"></agm-marker>
</agm-map>
```

// cc @lazarljubenovic @jinder 