### PR TITLE
fix(polygon): add back Input() decorator to polygon's `editable` property

### DIFF
--- a/src/core/directives/polygon.ts
+++ b/src/core/directives/polygon.ts
@@ -73,7 +73,7 @@ export class AgmPolygon implements OnDestroy, OnChanges, AfterContentInit {
    * If set to true, the user can edit this shape by dragging the control
    * points shown at the vertices and on each segment. Defaults to false.
    */
-  editable: boolean = false;
+  @Input() editable: boolean = false;
 
   /**
    * The fill color. All CSS3 colors are supported except for extended


### PR DESCRIPTION
It appears to have been left out in #989's refactoring