### PR TITLE
Pass the disableAutoPan property through to the Google Maps InfoWindow options for infowindow creation.

### DIFF
--- a/packages/core/services/managers/info-window-manager.ts
+++ b/packages/core/services/managers/info-window-manager.ts
@@ -67,6 +67,7 @@ export class InfoWindowManager {
       content: infoWindow.content,
       maxWidth: infoWindow.maxWidth,
       zIndex: infoWindow.zIndex,
+      disableAutoPan: infoWindow.disableAutoPan
     };
     if (typeof infoWindow.latitude === 'number' && typeof infoWindow.longitude === 'number') {
       options.position = {lat: infoWindow.latitude, lng: infoWindow.longitude};


### PR DESCRIPTION
Fix for disableAutoPan @Input() property on agm-info-window component not correctly setting disableAutoPan option on Google Map InfoWindows.