### PR TITLE
chore: depend on correct version

### DIFF
--- a/packages/js-marker-clusterer/package.tpl.json
+++ b/packages/js-marker-clusterer/package.tpl.json
@@ -21,7 +21,7 @@
   },
   "peerDependencies": {
     "@angular/core": "^4.0.0",
-    "@agm/core": "^1.0.0-beta.0",
+    "@agm/core": "^1.0.0-beta.1",
     "js-marker-clusterer": "^1.0.0"
   },
   "homepage": "https://github.com/SebastianM/angular-google-maps#readme"


### PR DESCRIPTION
@agm/js-markerer-cluster was depending on 1.0.0-beta.0 but only beta.1 has the required changes to `MakerManager`