### PR TITLE
fix(dataLayer): only update those data options which were changed

### DIFF
--- a/packages/core/services/managers/data-layer-manager.ts
+++ b/packages/core/services/managers/data-layer-manager.ts
@@ -58,10 +58,18 @@ export class DataLayerManager {
   setDataOptions(layer: AgmDataLayer, options: DataOptions)
   {
     this._layers.get(layer).then(l => {
-      l.setControlPosition(options.controlPosition);
-      l.setControls(options.controls);
-      l.setDrawingMode(options.drawingMode);
-      l.setStyle(options.style);
+      if (options.controlPosition) {
+        l.setControlPosition(options.controlPosition);
+      }
+      if (options.controls) {
+        l.setControls(options.controls);
+      }
+      if (options.drawingMode) {
+        l.setDrawingMode(options.drawingMode);
+      }
+      if (options.style) {
+        l.setStyle(options.style);
+      }
     });
   }
 


### PR DESCRIPTION
Fixes #1099 and probably similar issues, where updating the *data* of a data layer causes all data *options* to be cleared, because they are not passed along, hence `null` is passed in as a value to `setControlPosition` etc, instead of the actual values.

Note that this will obviously prevent actually clearing these 'data options' by setting them to null, but fixing this would require further refactoring.