### PR TITLE
Tweaks for Angular 5, Typescript 2.4 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
   },
   "homepage": "https://angular-maps.com",
   "peerDependencies": {
-    "@angular/common": "^4.0.0 || ^2.0.0",
-    "@angular/core": "^4.0.0 || ^2.0.0"
+    "@angular/common": "^5.0.0 || ^4.0.0",
+    "@angular/core": "^5.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "@angular/animations": "^4.0.0",

--- a/packages/core/services/managers/polygon-manager.ts
+++ b/packages/core/services/managers/polygon-manager.ts
@@ -4,12 +4,12 @@ import {Observer} from 'rxjs/Observer';
 
 import {AgmPolygon} from '../../directives/polygon';
 import {GoogleMapsAPIWrapper} from '../google-maps-api-wrapper';
-import {Polygon} from '../google-maps-types';
+import {Polygon, Polyline} from '../google-maps-types';
 
 @Injectable()
 export class PolygonManager {
-  private _polygons: Map<AgmPolygon, Promise<Polygon>> =
-      new Map<AgmPolygon, Promise<Polygon>>();
+  private _polygons: Map<AgmPolygon, Promise<Polygon | Polyline>> =
+      new Map<AgmPolygon, Promise<Polygon | Polyline>>();
 
   constructor(private _mapsWrapper: GoogleMapsAPIWrapper, private _zone: NgZone) {}
 

--- a/packages/core/services/maps-api-loader/lazy-maps-api-loader.ts
+++ b/packages/core/services/maps-api-loader/lazy-maps-api-loader.ts
@@ -14,7 +14,7 @@ export enum GoogleMapsScriptProtocol {
  * Token for the config of the LazyMapsAPILoader. Please provide an object of type {@link
  * LazyMapsAPILoaderConfig}.
  */
-export declare const LAZY_MAPS_API_CONFIG: InjectionToken<LazyMapsAPILoaderConfigLiteral>;
+export const LAZY_MAPS_API_CONFIG = new InjectionToken<LazyMapsAPILoaderConfigLiteral>('LazyMapsAPILoaderConfig');
 
 /**
  * Configuration for the {@link LazyMapsAPILoader}.

--- a/packages/core/services/maps-api-loader/lazy-maps-api-loader.ts
+++ b/packages/core/services/maps-api-loader/lazy-maps-api-loader.ts
@@ -14,7 +14,7 @@ export enum GoogleMapsScriptProtocol {
  * Token for the config of the LazyMapsAPILoader. Please provide an object of type {@link
  * LazyMapsAPILoaderConfig}.
  */
-export const LAZY_MAPS_API_CONFIG = new InjectionToken('angular-google-maps LAZY_MAPS_API_CONFIG');
+export declare const LAZY_MAPS_API_CONFIG: InjectionToken<LazyMapsAPILoaderConfigLiteral>;
 
 /**
  * Configuration for the {@link LazyMapsAPILoader}.


### PR DESCRIPTION
I updated the package.json peer dependencies and fixed the use of InjectionToken to make Typescript 2.4+ happy