### PR TITLE
feat(reload): add method to MapsApiLoader instance

### DIFF
--- a/packages/core/services/maps-api-loader/lazy-maps-api-loader.spec.ts
+++ b/packages/core/services/maps-api-loader/lazy-maps-api-loader.spec.ts
@@ -80,4 +80,39 @@ describe('Service: LazyMapsAPILoader', () => {
       expect(doc.body.appendChild).toHaveBeenCalledWith(scriptElem);
     });
   });
+
+  it('should delete and re-create the default script URL', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: MapsAPILoader, useClass: LazyMapsAPILoader},
+        {provide: WindowRef, useValue: windowRef}, {provide: DocumentRef, useValue: documentRef}
+      ]
+    });
+
+    inject([MapsAPILoader], (loader: LazyMapsAPILoader) => {
+      interface Script {
+        src?: string;
+        async?: boolean;
+        defer?: boolean;
+        type?: string;
+        remove?: Function;
+      }
+      const scriptElem: Script = {};
+      (<jasmine.Spy>doc.createElement).and.returnValue(scriptElem);
+      doc.body = jasmine.createSpyObj('body', ['appendChild']);
+
+      loader.load();
+      expect(doc.createElement).toHaveBeenCalled();
+      expect(doc.createElement).toHaveBeenCalled();
+      expect(doc.body.appendChild).toHaveBeenCalledWith(scriptElem);
+      loader.reload();
+      expect(scriptElem.remove).toHaveBeenCalled();
+      expect(loader.load).toHaveBeenCalled();
+      expect(doc.createElement).toHaveBeenCalled();
+      expect(scriptElem.src).toContain('http://maps.googleapis.com/maps/api/js');
+      expect(scriptElem.src).toContain('v=3');
+      expect(scriptElem.src).toContain('callback=angular2GoogleMapsLazyMapsAPILoader');
+      expect(doc.body.appendChild).toHaveBeenCalledWith(scriptElem);
+    });
+  });
 });

--- a/packages/core/services/maps-api-loader/lazy-maps-api-loader.spec.ts
+++ b/packages/core/services/maps-api-loader/lazy-maps-api-loader.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed, inject} from '@angular/core/testing';
+import {TestBed, inject, async} from '@angular/core/testing';
 
 import {DocumentRef, WindowRef} from '../../utils/browser-globals';
 
@@ -14,105 +14,117 @@ describe('Service: LazyMapsAPILoader', () => {
     doc = jasmine.createSpyObj<DocumentRef>('Document', ['createElement']);
     documentRef = jasmine.createSpyObj<DocumentRef>('Document', ['getNativeDocument']);
     (<any>documentRef.getNativeDocument).and.returnValue(doc);
-    windowRef = {};
+    windowRef = {
+      getNativeWindow: () => {
+        return {};
+      }
+    };
   });
 
-  it('should create the default script URL', () => {
-    TestBed.configureTestingModule({
-      providers: [
-        {provide: MapsAPILoader, useClass: LazyMapsAPILoader},
-        {provide: WindowRef, useValue: windowRef}, {provide: DocumentRef, useValue: documentRef}
-      ]
+  describe('loading', () => {
+    beforeEach(() => {
+      const lazyLoadingConf:
+          LazyMapsAPILoaderConfigLiteral = {};
+      TestBed.configureTestingModule({
+        providers: [
+          {provide: MapsAPILoader, useClass: LazyMapsAPILoader},
+          {provide: WindowRef, useValue: windowRef}, {provide: DocumentRef, useValue: documentRef},
+          {provide: LAZY_MAPS_API_CONFIG, useValue: lazyLoadingConf}
+        ]
+      });
     });
 
-    inject([MapsAPILoader], (loader: LazyMapsAPILoader) => {
-      interface Script {
-        src?: string;
-        async?: boolean;
-        defer?: boolean;
-        type?: string;
-      }
-      const scriptElem: Script = {};
-      (<jasmine.Spy>doc.createElement).and.returnValue(scriptElem);
-      doc.body = jasmine.createSpyObj('body', ['appendChild']);
+    it('should create the default script URL', async(inject(
+        [MapsAPILoader],
+        (loader: LazyMapsAPILoader) => {
+          interface Script {
+            src?: string;
+            async?: boolean;
+            defer?: boolean;
+            type?: string;
+          }
+          const scriptElem: Script = {};
+          (<jasmine.Spy>doc.createElement).and.returnValue(scriptElem);
+          doc.body = jasmine.createSpyObj('body', ['appendChild']);
 
-      loader.load();
-      expect(doc.createElement).toHaveBeenCalled();
-      expect(scriptElem.type).toEqual('text/javascript');
-      expect(scriptElem.async).toEqual(true);
-      expect(scriptElem.defer).toEqual(true);
-      expect(scriptElem.src).toBeDefined();
-      expect(scriptElem.src).toContain('https://maps.googleapis.com/maps/api/js');
-      expect(scriptElem.src).toContain('v=3');
-      expect(scriptElem.src).toContain('callback=angular2GoogleMapsLazyMapsAPILoader');
-      expect(doc.body.appendChild).toHaveBeenCalledWith(scriptElem);
-    });
+          loader.load();
+          expect(doc.createElement).toHaveBeenCalled();
+          expect(scriptElem.type).toEqual('text/javascript');
+          expect(scriptElem.async).toEqual(true);
+          expect(scriptElem.defer).toEqual(true);
+          expect(scriptElem.src).toBeDefined();
+          expect(scriptElem.src).toContain('https://maps.googleapis.com/maps/api/js');
+          expect(scriptElem.src).toContain('v=3');
+          expect(scriptElem.src).toContain('callback=angular2GoogleMapsLazyMapsAPILoader');
+          expect(doc.body.appendChild).toHaveBeenCalledWith(scriptElem);
+        }))
+    );
+
+    it('should delete and re-create the default script URL', async(inject(
+        [MapsAPILoader],
+        (loader: LazyMapsAPILoader) => {
+          interface Script {
+            src?: string;
+            async?: boolean;
+            defer?: boolean;
+            type?: string;
+            remove?: Function;
+          }
+          const scriptElem: Script = {
+            remove: () => {}
+          };
+          (<jasmine.Spy>doc.createElement).and.returnValue(scriptElem);
+          doc.body = jasmine.createSpyObj('body', ['appendChild']);
+          loader.load();
+          expect(doc.createElement).toHaveBeenCalled();
+          expect(doc.body.appendChild).toHaveBeenCalledWith(scriptElem);
+          expect(scriptElem.src).toContain('https://maps.googleapis.com/maps/api/js');
+          expect(scriptElem.src).toContain('v=3');
+          expect(scriptElem.src).toContain('callback=angular2GoogleMapsLazyMapsAPILoader');
+          loader.reload();
+          expect(doc.createElement).toHaveBeenCalled();
+          expect(scriptElem.src).toContain('https://maps.googleapis.com/maps/api/js');
+          expect(scriptElem.src).toContain('v=3');
+          expect(scriptElem.src).toContain('callback=angular2GoogleMapsLazyMapsAPILoader');
+          expect(doc.body.appendChild).toHaveBeenCalledWith(scriptElem);
+
+      })));
   });
 
-  it('should load the script via http when provided', () => {
-    const lazyLoadingConf:
-        LazyMapsAPILoaderConfigLiteral = {protocol: GoogleMapsScriptProtocol.HTTP};
+  describe('loading via http', () => {
+    beforeEach(() => {
+      const lazyLoadingConf:
+          LazyMapsAPILoaderConfigLiteral = {protocol: GoogleMapsScriptProtocol.HTTP};
 
-    TestBed.configureTestingModule({
-      providers: [
-        {provide: MapsAPILoader, useClass: LazyMapsAPILoader},
-        {provide: WindowRef, useValue: windowRef}, {provide: DocumentRef, useValue: documentRef},
-        {provide: LAZY_MAPS_API_CONFIG, useValue: lazyLoadingConf}
-      ]
+      TestBed.configureTestingModule({
+        providers: [
+          {provide: MapsAPILoader, useClass: LazyMapsAPILoader},
+          {provide: WindowRef, useValue: windowRef}, {provide: DocumentRef, useValue: documentRef},
+          {provide: LAZY_MAPS_API_CONFIG, useValue: lazyLoadingConf}
+        ]
+      });
     });
 
-    inject([MapsAPILoader], (loader: LazyMapsAPILoader) => {
-      interface Script {
-        src?: string;
-        async?: boolean;
-        defer?: boolean;
-        type?: string;
-      }
-      const scriptElem: Script = {};
-      (<jasmine.Spy>doc.createElement).and.returnValue(scriptElem);
-      doc.body = jasmine.createSpyObj('body', ['appendChild']);
+    it('should load the script via http when provided', async(inject(
+        [MapsAPILoader],
+        (loader: LazyMapsAPILoader) => {
+          interface Script {
+            src?: string;
+            async?: boolean;
+            defer?: boolean;
+            type?: string;
+          }
+          const scriptElem: Script = {};
+          (<jasmine.Spy>doc.createElement).and.returnValue(scriptElem);
+          doc.body = jasmine.createSpyObj('body', ['appendChild']);
 
-      loader.load();
-      expect(doc.createElement).toHaveBeenCalled();
-      expect(scriptElem.src).toContain('http://maps.googleapis.com/maps/api/js');
-      expect(scriptElem.src).toContain('v=3');
-      expect(scriptElem.src).toContain('callback=angular2GoogleMapsLazyMapsAPILoader');
-      expect(doc.body.appendChild).toHaveBeenCalledWith(scriptElem);
-    });
-  });
-
-  it('should delete and re-create the default script URL', () => {
-    TestBed.configureTestingModule({
-      providers: [
-        {provide: MapsAPILoader, useClass: LazyMapsAPILoader},
-        {provide: WindowRef, useValue: windowRef}, {provide: DocumentRef, useValue: documentRef}
-      ]
-    });
-
-    inject([MapsAPILoader], (loader: LazyMapsAPILoader) => {
-      interface Script {
-        src?: string;
-        async?: boolean;
-        defer?: boolean;
-        type?: string;
-        remove?: Function;
-      }
-      const scriptElem: Script = {};
-      (<jasmine.Spy>doc.createElement).and.returnValue(scriptElem);
-      doc.body = jasmine.createSpyObj('body', ['appendChild']);
-
-      loader.load();
-      expect(doc.createElement).toHaveBeenCalled();
-      expect(doc.createElement).toHaveBeenCalled();
-      expect(doc.body.appendChild).toHaveBeenCalledWith(scriptElem);
-      loader.reload();
-      expect(scriptElem.remove).toHaveBeenCalled();
-      expect(loader.load).toHaveBeenCalled();
-      expect(doc.createElement).toHaveBeenCalled();
-      expect(scriptElem.src).toContain('http://maps.googleapis.com/maps/api/js');
-      expect(scriptElem.src).toContain('v=3');
-      expect(scriptElem.src).toContain('callback=angular2GoogleMapsLazyMapsAPILoader');
-      expect(doc.body.appendChild).toHaveBeenCalledWith(scriptElem);
-    });
+          loader.load();
+          expect(doc.createElement).toHaveBeenCalled();
+          expect(scriptElem.src).toContain('http://maps.googleapis.com/maps/api/js');
+          expect(scriptElem.src).toContain('v=3');
+          expect(scriptElem.src).toContain('callback=angular2GoogleMapsLazyMapsAPILoader');
+          expect(doc.body.appendChild).toHaveBeenCalledWith(scriptElem);
+        }
+    )));
   });
 });


### PR DESCRIPTION
If the script don't load, the promise returned from the `load` method will be rejected. Catch that and call reload whenever you want.
Use case : offline browser that catches back a network.