### PR TITLE
Added complex marker icon

### DIFF
--- a/packages/core/directives/marker.ts
+++ b/packages/core/directives/marker.ts
@@ -65,9 +65,9 @@ export class AgmMarker implements OnDestroy, OnChanges, AfterContentInit {
   @Input('markerDraggable') draggable: boolean = false;
 
   /**
-   * Icon (the URL of the image) for the foreground.
+   * Icon (the URL or a complex icon) for the foreground.
    */
-  @Input() iconUrl: string;
+  @Input() icon: mapTypes.Icon | string;
 
   /**
    * If true, the marker is visible
@@ -167,7 +167,7 @@ export class AgmMarker implements OnDestroy, OnChanges, AfterContentInit {
     if (changes['draggable']) {
       this._markerManager.updateDraggable(this);
     }
-    if (changes['iconUrl']) {
+    if (changes['icon']) {
       this._markerManager.updateIcon(this);
     }
     if (changes['opacity']) {

--- a/packages/core/services/google-maps-types.ts
+++ b/packages/core/services/google-maps-types.ts
@@ -28,7 +28,7 @@ export interface Marker extends MVCObject {
   setTitle(title: string): void;
   setLabel(label: string|MarkerLabel): void;
   setDraggable(draggable: boolean): void;
-  setIcon(icon: string): void;
+  setIcon(icon: string|Icon): void;
   setOpacity(opacity: number): void;
   setVisible(visible: boolean): void;
   setZIndex(zIndex: number): void;
@@ -42,7 +42,7 @@ export interface MarkerOptions {
   map?: GoogleMap;
   label?: string|MarkerLabel;
   draggable?: boolean;
-  icon?: string;
+  icon?: string|Icon;
   opacity?: number;
   visible?: boolean;
   zIndex?: number;
@@ -202,9 +202,6 @@ export interface MapsEventListener { remove(): void; }
 export interface Size {
   height: number;
   width: number;
-  constructor(width: number, height: number, widthUnit?: string, heightUnit?: string): void;
-  equals(other: Size): boolean;
-  toString(): string;
 }
 
 export interface InfoWindowOptions {
@@ -219,8 +216,15 @@ export interface InfoWindowOptions {
 export interface Point {
   x: number;
   y: number;
-  equals(other: Point): boolean;
-  toString(): string;
+}
+
+export interface Icon {
+  anchor?: Point;
+  labelOrigin?: Point;
+  origin?: Point;
+  scaledSize?: Size;
+  size?: Size;
+  url: string;
 }
 
 export interface GoogleSymbol {

--- a/packages/core/services/managers/marker-manager.spec.ts
+++ b/packages/core/services/managers/marker-manager.spec.ts
@@ -63,7 +63,7 @@ describe('MarkerManager', () => {
            }));
   });
 
-  describe('set marker icon', () => {
+  describe('set url marker icon', () => {
     it('should update that marker via setIcon method when the markerUrl changes',
        async(inject(
            [MarkerManager, GoogleMapsAPIWrapper],
@@ -88,11 +88,50 @@ describe('MarkerManager', () => {
                title: undefined,
                clickable: true
              });
-             const iconUrl = 'http://angular-maps.com/icon.png';
-             newMarker.iconUrl = iconUrl;
+             const url = 'http://angular-maps.com/icon.png';
+             newMarker.icon = url;
              return markerManager.updateIcon(newMarker).then(
-                 () => { expect(markerInstance.setIcon).toHaveBeenCalledWith(iconUrl); });
+                 () => { expect(markerInstance.setIcon).toHaveBeenCalledWith(url); });
            })));
+  });
+
+  describe('set complex marker icon', () => {
+    it('should update that marker via setIcon method when the markerUrl changes',
+      async(inject(
+        [MarkerManager, GoogleMapsAPIWrapper],
+        (markerManager: MarkerManager, apiWrapper: GoogleMapsAPIWrapper) => {
+          const newMarker = new AgmMarker(markerManager);
+          newMarker.latitude = 34.4;
+          newMarker.longitude = 22.3;
+          newMarker.label = 'A';
+
+          const markerInstance: Marker = jasmine.createSpyObj('Marker', ['setMap', 'setIcon']);
+          (<any>apiWrapper.createMarker).and.returnValue(Promise.resolve(markerInstance));
+
+          markerManager.addMarker(newMarker);
+          expect(apiWrapper.createMarker).toHaveBeenCalledWith({
+            position: {lat: 34.4, lng: 22.3},
+            label: 'A',
+            draggable: false,
+            icon: undefined,
+            opacity: 1,
+            visible: true,
+            zIndex: 1,
+            title: undefined,
+            clickable: true
+          });
+          const icon = {
+            anchor: {x: 16, y: 16},
+            labelOrigin: {x: 0, y: 0},
+            origin: {x: 0, y: 0},
+            scaledSize: {height: 32, width: 32},
+            size: {height: 32, width: 32},
+            url: 'http://angular-maps.com/icon.png'
+          };
+          newMarker.icon = icon;
+          return markerManager.updateIcon(newMarker).then(
+            () => { expect(markerInstance.setIcon).toHaveBeenCalledWith(icon); });
+        })));
   });
 
   describe('set marker opacity', () => {

--- a/packages/core/services/managers/marker-manager.ts
+++ b/packages/core/services/managers/marker-manager.ts
@@ -46,7 +46,7 @@ export class MarkerManager {
   }
 
   updateIcon(marker: AgmMarker): Promise<void> {
-    return this._markers.get(marker).then((m: Marker) => m.setIcon(marker.iconUrl));
+    return this._markers.get(marker).then((m: Marker) => m.setIcon(marker.icon));
   }
 
   updateOpacity(marker: AgmMarker): Promise<void> {
@@ -70,7 +70,7 @@ export class MarkerManager {
       position: {lat: marker.latitude, lng: marker.longitude},
       label: marker.label,
       draggable: marker.draggable,
-      icon: marker.iconUrl,
+      icon: marker.icon,
       opacity: marker.opacity,
       visible: marker.visible,
       zIndex: marker.zIndex,

--- a/packages/js-marker-clusterer/services/managers/cluster-manager.spec.ts
+++ b/packages/js-marker-clusterer/services/managers/cluster-manager.spec.ts
@@ -63,7 +63,7 @@ describe('ClusterManager', () => {
            }));
   });
 
-  describe('set marker icon', () => {
+  describe('set url marker icon', () => {
     it('should update that marker via setIcon method when the markerUrl changes',
        async(inject(
            [ClusterManager, GoogleMapsAPIWrapper],
@@ -88,11 +88,50 @@ describe('ClusterManager', () => {
                title: undefined,
                clickable: true
              }, false);
-             const iconUrl = 'http://angular-maps.com/icon.png';
-             newMarker.iconUrl = iconUrl;
+             const url = 'http://angular-maps.com/icon.png';
+             newMarker.icon = url;
              return markerManager.updateIcon(newMarker).then(
-                 () => { expect(markerInstance.setIcon).toHaveBeenCalledWith(iconUrl); });
+                 () => { expect(markerInstance.setIcon).toHaveBeenCalledWith(url); });
            })));
+  });
+
+  describe('set complex marker icon', () => {
+    it('should update that marker via setIcon method when the markerUrl changes',
+      async(inject(
+        [ClusterManager, GoogleMapsAPIWrapper],
+        (markerManager: ClusterManager, apiWrapper: GoogleMapsAPIWrapper) => {
+          const newMarker = new AgmMarker(markerManager);
+          newMarker.latitude = 34.4;
+          newMarker.longitude = 22.3;
+          newMarker.label = 'A';
+
+          const markerInstance: Marker = jasmine.createSpyObj('Marker', ['setMap', 'setIcon']);
+          (<any>apiWrapper.createMarker).and.returnValue(Promise.resolve(markerInstance));
+
+          markerManager.addMarker(newMarker);
+          expect(apiWrapper.createMarker).toHaveBeenCalledWith({
+            position: {lat: 34.4, lng: 22.3},
+            label: 'A',
+            draggable: false,
+            icon: undefined,
+            opacity: 1,
+            visible: true,
+            zIndex: 1,
+            title: undefined,
+            clickable: true
+          }, false);
+          const icon = {
+            anchor: {x: 16, y: 16},
+            labelOrigin: {x: 0, y: 0},
+            origin: {x: 0, y: 0},
+            scaledSize: {height: 32, width: 32},
+            size: {height: 32, width: 32},
+            url: 'http://angular-maps.com/icon.png'
+          };
+          newMarker.icon = icon;
+          return markerManager.updateIcon(newMarker).then(
+            () => { expect(markerInstance.setIcon).toHaveBeenCalledWith(icon); });
+        })));
   });
 
   describe('set marker opacity', () => {

--- a/packages/js-marker-clusterer/services/managers/cluster-manager.ts
+++ b/packages/js-marker-clusterer/services/managers/cluster-manager.ts
@@ -40,7 +40,7 @@ export class ClusterManager extends MarkerManager {
         },
         label: marker.label,
         draggable: marker.draggable,
-        icon: marker.iconUrl,
+        icon: marker.icon,
         opacity: marker.opacity,
         visible: marker.visible,
         zIndex: marker.zIndex,


### PR DESCRIPTION
Add functionality to create a complex marker icon

#517 #1013 #1057 #1088

Example:
```
<agm-marker
   [latitude]="location.latitude"
   [longitude]="location.longitude"
   [icon]="location.icon">
 </agm-marker>
```