### PR TITLE
(fix) auto-convert to number for marker input

### DIFF
--- a/packages/core/directives/marker.ts
+++ b/packages/core/directives/marker.ts
@@ -146,8 +146,12 @@ export class AgmMarker implements OnDestroy, OnChanges, AfterContentInit {
 
   /** @internal */
   ngOnChanges(changes: {[key: string]: SimpleChange}) {
-    if (typeof this.latitude !== 'number' || typeof this.longitude !== 'number') {
-      return;
+    if (typeof this.latitude !== 'number') {
+      this.latitude = Number(this.latitude);
+    }
+
+    if (typeof this.longitude !== 'number') {
+      this.longitude = Number(this.longitude);
     }
     if (!this._markerAddedToManger) {
       this._markerManager.addMarker(this);


### PR DESCRIPTION
change from no warnings/errors/functionality to
automatically converting latitude and longitude inputs
to numbers if they are not of type number

closes #771