### PR TITLE
Fix(lazy-loader): Add check if google maps script was already loaded

### DIFF
--- a/packages/core/services/maps-api-loader/lazy-maps-api-loader.ts
+++ b/packages/core/services/maps-api-loader/lazy-maps-api-loader.ts
@@ -93,6 +93,12 @@ export class LazyMapsAPILoader extends MapsAPILoader {
   }
 
   load(): Promise<void> {
+    const window = <any>this._windowRef.getNativeWindow();
+    if (window.google && window.google.maps) {
+      // Google maps already loaded on the page.
+      return Promise.resolve();
+    }
+
     if (this._scriptLoadingPromise) {
       return this._scriptLoadingPromise;
     }


### PR DESCRIPTION
Check in lazy loader if google maps script was loaded and maps are initialized in window.