### PR TITLE
Cluster manager fix

### DIFF
--- a/packages/js-marker-clusterer/services/managers/cluster-manager.ts
+++ b/packages/js-marker-clusterer/services/managers/cluster-manager.ts
@@ -64,6 +64,7 @@ export class ClusterManager extends MarkerManager {
     }
     return m.then((m: Marker) => {
       this._zone.run(() => {
+        m.setMap(null);
         this._clustererInstance.then(cluster => {
           cluster.removeMarker(m);
           this._markers.delete(marker);


### PR DESCRIPTION
`Delete a marker` unit test failed because `setMap(null)` was not called in the `deleteMarker` method