### PR TITLE
feat(polyline): add icon property

### DIFF
--- a/packages/core/directives/polyline.ts
+++ b/packages/core/directives/polyline.ts
@@ -1,7 +1,7 @@
 import { AfterContentInit, ContentChildren, Directive, EventEmitter, OnChanges, OnDestroy, QueryList, SimpleChanges, Input, Output } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 
-import { PolyMouseEvent } from '../services/google-maps-types';
+import { PolyMouseEvent, IconSequence } from '../services/google-maps-types';
 import { PolylineManager } from '../services/managers/polyline-manager';
 import { AgmPolylinePoint } from './polyline-point';
 
@@ -41,6 +41,11 @@ export class AgmPolyline implements OnDestroy, OnChanges, AfterContentInit {
    * Indicates whether this Polyline handles mouse events. Defaults to true.
    */
   @Input() clickable: boolean = true;
+
+  /**
+   * icons of the polyline
+   */
+  @Input() icons: IconSequence[] = undefined;
 
   /**
    * If set to true, the user can drag this shape over the map. The geodesic property defines the

--- a/packages/core/map-types.ts
+++ b/packages/core/map-types.ts
@@ -4,6 +4,7 @@ import {LatLngLiteral} from './services/google-maps-types';
 export {
   KmlMouseEvent,
   DataMouseEvent,
+  IconSequence,
   LatLngBounds,
   LatLngBoundsLiteral,
   LatLngLiteral,

--- a/packages/core/services/google-maps-types.ts
+++ b/packages/core/services/google-maps-types.ts
@@ -231,7 +231,7 @@ export interface GoogleSymbol {
   fillColor?: string;
   fillOpacity?: string;
   labelOrigin?: Point;
-  path?: string;
+  path?: string | number;
   rotation?: number;
   scale?: number;
   strokeColor?: string;
@@ -251,7 +251,7 @@ export interface PolylineOptions {
   draggable?: boolean;
   editable?: boolean;
   geodesic?: boolean;
-  icon?: Array<IconSequence>;
+  icons?: Array<IconSequence>;
   map?: GoogleMap;
   path?: Array<LatLng>|Array<LatLng|LatLngLiteral>;
   strokeColor?: string;

--- a/packages/core/services/managers/polyline-manager.spec.ts
+++ b/packages/core/services/managers/polyline-manager.spec.ts
@@ -37,7 +37,8 @@ describe('PolylineManager', () => {
                strokeWeight: undefined,
                visible: true,
                zIndex: undefined,
-               path: []
+               path: [],
+               icons: undefined
              });
            }));
   });

--- a/packages/core/services/managers/polyline-manager.ts
+++ b/packages/core/services/managers/polyline-manager.ts
@@ -33,7 +33,8 @@ export class PolylineManager {
       strokeWeight: line.strokeWeight,
       visible: line.visible,
       zIndex: line.zIndex,
-      path: path
+      path: path,
+      icons: line.icons
     });
     this._polylines.set(line, polylinePromise);
   }


### PR DESCRIPTION
Adds icon property to polyline.

Closes #1007

Took up [the old PR](#1007) as it had conflicts and I would like to see this merged.

@SebastianM, I believe the two comments remaining on the old PR should already be addressed. The `ngOnChanges` of `polyline.ts` should already update all of the options.