### PR TITLE
fix(LazyMapsAPILoader): move _scriptLoadingPromise to global scope

### DIFF
--- a/packages/core/services/maps-api-loader/lazy-maps-api-loader.spec.ts
+++ b/packages/core/services/maps-api-loader/lazy-maps-api-loader.spec.ts
@@ -69,6 +69,17 @@ describe('Service: LazyMapsAPILoader', () => {
     expect(doc.body.appendChild).not.toHaveBeenCalledWith();
   }));
 
+  it('should not append a second script to body when the script loading request is processing',
+      inject([MapsAPILoader, WindowRef, DocumentRef],
+      (loader: LazyMapsAPILoader, windowRed: WindowRef, documentRef: DocumentRef) => {
+    (<jasmine.Spy>doc.getElementById).and.returnValue(null);
+    (<jasmine.Spy>doc.createElement).and.returnValue({});
+    loader.load();
+    const secondLoader = new LazyMapsAPILoader(null, windowRef, documentRef);
+    secondLoader.load();
+    expect(doc.body.appendChild).toHaveBeenCalledTimes(1);
+}));
+
   it('should load the script via http when provided', () => {
     const lazyLoadingConf:
         LazyMapsAPILoaderConfigLiteral = {protocol: GoogleMapsScriptProtocol.HTTP};

--- a/packages/core/services/maps-api-loader/lazy-maps-api-loader.ts
+++ b/packages/core/services/maps-api-loader/lazy-maps-api-loader.ts
@@ -80,7 +80,6 @@ export interface LazyMapsAPILoaderConfigLiteral {
 
 @Injectable()
 export class LazyMapsAPILoader extends MapsAPILoader {
-  protected _scriptLoadingPromise: Promise<void>;
   protected _config: LazyMapsAPILoaderConfigLiteral;
   protected _windowRef: WindowRef;
   protected _documentRef: DocumentRef;
@@ -100,13 +99,13 @@ export class LazyMapsAPILoader extends MapsAPILoader {
       return Promise.resolve();
     }
 
+    if (window._scriptLoadingPromise) {
+      return window._scriptLoadingPromise;
+    }
+
     if (this._documentRef.getNativeDocument().getElementById(this._SCRIPT_ID)) {
       // this can happen in HMR situations or Stackblitz.io editors.
       return Promise.resolve();
-    }
-
-    if (this._scriptLoadingPromise) {
-      return this._scriptLoadingPromise;
     }
 
     const script = this._documentRef.getNativeDocument().createElement('script');
@@ -117,7 +116,7 @@ export class LazyMapsAPILoader extends MapsAPILoader {
     const callbackName: string = `agmLazyMapsAPILoader`;
     script.src = this._getScriptSrc(callbackName);
 
-    this._scriptLoadingPromise = new Promise<void>((resolve: Function, reject: Function) => {
+    window._scriptLoadingPromise = new Promise<void>((resolve: Function, reject: Function) => {
       (<any>this._windowRef.getNativeWindow())[callbackName] = () => {
         resolve();
       };
@@ -128,7 +127,7 @@ export class LazyMapsAPILoader extends MapsAPILoader {
     });
 
     this._documentRef.getNativeDocument().body.appendChild(script);
-    return this._scriptLoadingPromise;
+    return window._scriptLoadingPromise;
   }
 
   protected _getScriptSrc(callbackName: string): string {


### PR DESCRIPTION
An issue might occur where having multiple GMap loading at the same time, in multiple
instances. Instead of returning this._scriptLoadingPromise, we return a global one.
Sample code to replicate the issue:
https://stackblitz.com/edit/angular-google-maps-multiple-maps-issue?file=app%2Fapp.component.ts

fix #1385