### PR TITLE
feat: markerwithlabel support

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   "homepage": "https://angular-maps.com",
   "peerDependencies": {
     "@angular/common": "^4.0.0 || ^5.0.0",
-    "@angular/core": "^4.0.0 || ^5.0.0"
+    "@angular/core": "^4.0.0 || ^5.0.0",
+    "markerwithlabel": "^2.0.1"
   },
   "devDependencies": {
     "@angular/animations": "^4.0.0",
@@ -79,6 +80,7 @@
     "istanbul-instrumenter-loader": "^2.0.0",
     "jasmine-core": "2.5.0",
     "js-marker-clusterer": "^1.0.0",
+    "markerwithlabel": "^2.0.1",
     "karma": "^1.3.0",
     "karma-chrome-launcher": "2.0.0",
     "karma-coverage": "^1.1.1",
@@ -105,7 +107,8 @@
     "jspmNodeConversion": false,
     "dependencies": {
       "@angular/common": "^4.0.0 || ^5.0.0",
-      "@angular/core": "^4.0.0 || ^5.0.0"
+      "@angular/core": "^4.0.0 || ^5.0.0",
+      "markerwithlabel": "^2.0.1"
     }
   }
 }

--- a/packages/core/directives/marker.ts
+++ b/packages/core/directives/marker.ts
@@ -39,7 +39,8 @@ let markerId = 0;
   selector: 'agm-marker',
   inputs: [
     'latitude', 'longitude', 'title', 'label', 'draggable: markerDraggable', 'iconUrl',
-    'openInfoWindow', 'opacity', 'visible', 'zIndex', 'animation'
+    'openInfoWindow', 'opacity', 'visible', 'zIndex', 'animation', 'markerWithLabel',
+    'labelContent', 'labelAnchor', 'labelClass', 'labelInBackground'
   ],
   outputs: ['markerClick', 'dragEnd', 'mouseOver', 'mouseOut']
 })
@@ -63,6 +64,31 @@ export class AgmMarker implements OnDestroy, OnChanges, AfterContentInit {
    * The label (a single uppercase character) for the marker.
    */
   @Input() label: string | MarkerLabel;
+
+  /**
+   * Use MarkerWithLabel API from googlemaps/v3-utility-library
+   */
+  @Input() markerWithLabel: boolean = false;
+
+  /**
+   * Label content (text or HTML Node)
+   */
+  @Input() labelContent: string;
+
+  /**
+   * Label position
+   */
+  @Input() labelAnchor: mapTypes.Point;
+
+  /**
+   * Class name for label element
+   */
+  @Input() labelClass: string;
+
+  /**
+   * Draw label in background/foreground of its marker
+   */
+  @Input() labelInBackground: boolean;
 
   /**
    * If true, the marker can be dragged. Default value is false.
@@ -175,6 +201,12 @@ export class AgmMarker implements OnDestroy, OnChanges, AfterContentInit {
     }
     if (changes['label']) {
       this._markerManager.updateLabel(this);
+    }
+    if (changes['labelContent']) {
+      this._markerManager.updateLabelContent(this);
+    }
+    if (changes['labelClass']) {
+      this._markerManager.updateLabelClass(this);
     }
     if (changes['draggable']) {
       this._markerManager.updateDraggable(this);

--- a/packages/core/services/google-maps-api-wrapper.ts
+++ b/packages/core/services/google-maps-api-wrapper.ts
@@ -9,6 +9,7 @@ import {MapsAPILoader} from './maps-api-loader/maps-api-loader';
 
 // todo: add types for this
 declare var google: any;
+declare var require: any;
 
 /**
  * Wrapper class that handles the communication with the Google Maps Javascript
@@ -18,6 +19,7 @@ declare var google: any;
 export class GoogleMapsAPIWrapper {
   private _map: Promise<mapTypes.GoogleMap>;
   private _mapResolver: (value?: mapTypes.GoogleMap) => void;
+  private _markerWithLabel: any;
 
   constructor(private _loader: MapsAPILoader, private _zone: NgZone) {
     this._map =
@@ -27,6 +29,7 @@ export class GoogleMapsAPIWrapper {
   createMap(el: HTMLElement, mapOptions: mapTypes.MapOptions): Promise<void> {
     return this._loader.load().then(() => {
       const map = new google.maps.Map(el, mapOptions);
+      this._markerWithLabel = require('markerwithlabel')(google.maps);
       this._mapResolver(<mapTypes.GoogleMap>map);
       return;
     });
@@ -46,6 +49,16 @@ export class GoogleMapsAPIWrapper {
         options.map = map;
       }
       return new google.maps.Marker(options);
+    });
+  }
+
+  createMarkerWithLabel(options: mapTypes.MarkerOptions = <mapTypes.MarkerOptions>{}, addToMap: boolean = true):
+      Promise<mapTypes.Marker> {
+    return this._map.then((map: mapTypes.GoogleMap) => {
+      if (addToMap) {
+        options.map = map;
+      }
+      return new this._markerWithLabel(options);
     });
   }
 

--- a/packages/core/services/google-maps-types.ts
+++ b/packages/core/services/google-maps-types.ts
@@ -36,6 +36,7 @@ export interface Marker extends MVCObject {
   setAnimation(animation: any): void;
   getLabel(): MarkerLabel;
   setClickable(clickable: boolean): void;
+  setOptions(options: any): void;
 }
 
 export interface MarkerOptions {
@@ -50,6 +51,10 @@ export interface MarkerOptions {
   zIndex?: number;
   clickable: boolean;
   animation?: any;
+  labelContent?: string;
+  labelAnchor?: Point;
+  labelClass?: string;
+  labelInBackground?: boolean;
 }
 
 export interface MarkerLabel {

--- a/packages/core/services/managers/marker-manager.spec.ts
+++ b/packages/core/services/managers/marker-manager.spec.ts
@@ -3,7 +3,7 @@ import {TestBed, async, inject} from '@angular/core/testing';
 
 import {AgmMarker} from './../../directives/marker';
 import {GoogleMapsAPIWrapper} from './../google-maps-api-wrapper';
-import {Marker} from './../google-maps-types';
+import {Marker, Point} from './../google-maps-types';
 import {MarkerManager} from './../managers/marker-manager';
 
 describe('MarkerManager', () => {
@@ -13,7 +13,7 @@ describe('MarkerManager', () => {
         {provide: NgZone, useFactory: () => new NgZone({enableLongStackTrace: true})},
         MarkerManager, {
           provide: GoogleMapsAPIWrapper,
-          useValue: jasmine.createSpyObj('GoogleMapsAPIWrapper', ['createMarker'])
+          useValue: jasmine.createSpyObj('GoogleMapsAPIWrapper', ['createMarker', 'createMarkerWithLabel'])
         }
       ]
     });
@@ -41,6 +41,38 @@ describe('MarkerManager', () => {
                title: undefined,
                clickable: true,
                animation: undefined
+             });
+           }));
+  });
+
+  describe('Create a new marker with label', () => {
+    it('should call the mapsApiWrapper when creating a new marker with label',
+       inject(
+           [MarkerManager, GoogleMapsAPIWrapper],
+           (markerManager: MarkerManager, apiWrapper: GoogleMapsAPIWrapper) => {
+             const newMarker = new AgmMarker(markerManager);
+             newMarker.latitude = 34.4;
+             newMarker.longitude = 22.3;
+             newMarker.labelContent = 'A';
+             newMarker.labelClass = 'marker-class';
+             newMarker.labelInBackground = false;
+             newMarker.markerWithLabel = true;
+             markerManager.addMarker(newMarker);
+
+             expect(apiWrapper.createMarkerWithLabel).toHaveBeenCalledWith({
+               position: {lat: 34.4, lng: 22.3},
+               draggable: false,
+               icon: undefined,
+               opacity: 1,
+               visible: true,
+               zIndex: 1,
+               title: undefined,
+               clickable: true,
+               animation: undefined,
+               labelContent: 'A',
+               labelClass: 'marker-class',
+               labelInBackground: false,
+               labelAnchor: undefined
              });
            }));
   });

--- a/packages/core/services/managers/marker-manager.ts
+++ b/packages/core/services/managers/marker-manager.ts
@@ -5,7 +5,7 @@ import {Observer} from 'rxjs/Observer';
 import {AgmMarker} from './../../directives/marker';
 
 import {GoogleMapsAPIWrapper} from './../google-maps-api-wrapper';
-import {Marker} from './../google-maps-types';
+import {Marker, MarkerOptions} from './../google-maps-types';
 
 declare var google: any;
 
@@ -43,6 +43,14 @@ export class MarkerManager {
     return this._markers.get(marker).then((m: Marker) => { m.setLabel(marker.label); });
   }
 
+  updateLabelContent(marker: AgmMarker): Promise<void> {
+    return this._markers.get(marker).then((m: Marker) => { m.setOptions({labelContent: marker.labelContent }); });
+  }
+
+  updateLabelClass(marker: AgmMarker): Promise<void> {
+    return this._markers.get(marker).then((m: Marker) => { m.setOptions({labelClass: marker.labelClass}); });
+  }
+
   updateDraggable(marker: AgmMarker): Promise<void> {
     return this._markers.get(marker).then((m: Marker) => m.setDraggable(marker.draggable));
   }
@@ -78,19 +86,27 @@ export class MarkerManager {
   }
 
   addMarker(marker: AgmMarker) {
-    const markerPromise = this._mapsWrapper.createMarker({
+    let markerPromise: Promise<Marker>;
+    let markerOptions: MarkerOptions = {
       position: {lat: marker.latitude, lng: marker.longitude},
-      label: marker.label,
-      draggable: marker.draggable,
-      icon: marker.iconUrl,
-      opacity: marker.opacity,
-      visible: marker.visible,
-      zIndex: marker.zIndex,
-      title: marker.title,
-      clickable: marker.clickable,
-      animation: (typeof marker.animation === 'string') ? google.maps.Animation[marker.animation] : marker.animation
-    });
-
+        draggable: marker.draggable,
+        icon: marker.iconUrl,
+        opacity: marker.opacity,
+        visible: marker.visible,
+        zIndex: marker.zIndex,
+        title: marker.title,
+        clickable: marker.clickable,
+        animation: (typeof marker.animation === 'string') ? google.maps.Animation[marker.animation] : marker.animation,
+    };
+    if (marker.markerWithLabel) {
+      let {labelContent, labelClass, labelAnchor, labelInBackground} = marker;
+      Object.assign(markerOptions, {labelContent, labelClass, labelAnchor, labelInBackground});
+      markerPromise = this._mapsWrapper.createMarkerWithLabel(markerOptions);
+    } else {
+      let {label} = marker;
+      Object.assign(markerOptions, {label});
+      markerPromise = this._mapsWrapper.createMarker(markerOptions);
+    }
     this._markers.set(marker, markerPromise);
   }
 

--- a/rollup.core.config.js
+++ b/rollup.core.config.js
@@ -11,6 +11,7 @@ export default {
     '@angular/platform-browser': 'ng.platformBrowser',
     '@angular/platform-browser-dynamic': 'ng.platformBrowserDynamic',
     'js-marker-clusterer': 'MarkerClusterer',
+    'markerwithlabel': 'MarkerWithLabel',
     'rxjs/Subject': 'Rx',
     'rxjs/observable/PromiseObservable': 'Rx',
     'rxjs/operator/toPromise': 'Rx.Observable.prototype',
@@ -18,5 +19,5 @@ export default {
     'rxjs/Rx': 'Rx'
   },
   context: 'window',
-  external: ['rxjs', '@angular/core', 'rxjs/Observable', 'js-marker-clusterer']
+  external: ['rxjs', '@angular/core', 'rxjs/Observable', 'js-marker-clusterer', 'markerwithlabel']
 }

--- a/rollup.js-marker-clusterer.config.js
+++ b/rollup.js-marker-clusterer.config.js
@@ -18,5 +18,5 @@ export default {
     '@agm/core': 'ngmaps.core'
   },
   context: 'window',
-  external: ['rxjs', '@angular/core', 'rxjs/Observable', '@agm/core', 'js-marker-clusterer']
+  external: ['rxjs', '@angular/core', 'rxjs/Observable', '@agm/core', 'js-marker-clusterer', 'markerwithlabel']
 }


### PR DESCRIPTION
Added support for markerwithlabel from googlemaps/v3-utility-library.
Now it's possible to apply css class for the label.
(Need to install markerwithlabel separately because peerDependencies not installed with module).