### PR TITLE
Fix exception when using the library with Angular6

### DIFF
--- a/packages/snazzy-info-window/directives/snazzy-info-window.ts
+++ b/packages/snazzy-info-window/directives/snazzy-info-window.ts
@@ -225,7 +225,7 @@ export class AgmSnazzyInfoWindow implements AfterViewInit, OnDestroy, OnChanges 
             lng: this.longitude
           };
         }
-        this._nativeSnazzyInfoWindow = new elems[0](options);
+        this._nativeSnazzyInfoWindow = new elems[0].default(options);
       });
       this._snazzyInfoWindowInitialized.then(() => {
         if (this.isOpen) {


### PR DESCRIPTION
After upgrading to Angular6 I got the following exception:

ERROR Error: Uncaught (in promise): TypeError: elems[0] is not a constructor
TypeError: elems[0] is not a constructor
    at snazzy-info-window.js:146
    at ZoneDelegate.push../node_modules/zone.js/dist/zone.js.ZoneDelegate.invoke (zone.js:388)
    at Object.onInvoke (core.js:4071)
    at ZoneDelegate.push../node_modules/zone.js/dist/zone.js.ZoneDelegate.invoke (zone.js:387)
    at Zone.push../node_modules/zone.js/dist/zone.js.Zone.run (zone.js:138)

This PR fixes this issue.