### PR TITLE
fix memory leak when AgmMap is destroyed

### DIFF
--- a/packages/core/directives/map.ts
+++ b/packages/core/directives/map.ts
@@ -374,6 +374,9 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
   ngOnDestroy() {
     // unsubscribe all registered observable subscriptions
     this._observableSubscriptions.forEach((s) => s.unsubscribe());
+
+    // remove all listeners from the map instance
+    this._mapsWrapper.clearInstanceListeners();
   }
 
   /* @internal */

--- a/packages/core/services/google-maps-api-wrapper.ts
+++ b/packages/core/services/google-maps-api-wrapper.ts
@@ -107,6 +107,12 @@ export class GoogleMapsAPIWrapper {
     });
   }
 
+  clearInstanceListeners() {
+    this._map.then((map: mapTypes.GoogleMap) => {
+      google.maps.event.clearInstanceListeners(map);
+    });
+  }
+
   setCenter(latLng: mapTypes.LatLngLiteral): Promise<void> {
     return this._map.then((map: mapTypes.GoogleMap) => map.setCenter(latLng));
   }


### PR DESCRIPTION
When `AgmMap` destroyed, it stays in memory because it has bound event listeners.

Closes: #1207 

![agm leak](https://user-images.githubusercontent.com/19666213/40195257-aab29090-5a15-11e8-9ee7-ffb960ace203.JPG)

