### PR TITLE
feat(AgmMarker): Adding support for GoogleSymbol to be used for a marker icon

### DIFF
--- a/packages/core/directives/marker.ts
+++ b/packages/core/directives/marker.ts
@@ -9,6 +9,7 @@ import {MarkerManager} from '../services/managers/marker-manager';
 
 import {AgmInfoWindow} from './info-window';
 import {MarkerLabel} from '../map-types';
+import {GoogleSymbol} from '../services/google-maps-types';
 
 let markerId = 0;
 
@@ -73,7 +74,7 @@ export class AgmMarker implements OnDestroy, OnChanges, AfterContentInit {
   /**
    * Icon (the URL of the image) for the foreground.
    */
-  @Input() iconUrl: string;
+  @Input() icon: string | GoogleSymbol;
 
   /**
    * If true, the marker is visible

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -4,7 +4,7 @@ export * from './services';
 export * from './map-types';
 
 // Google Maps types
-export {LatLngBounds, LatLng, LatLngLiteral, MapTypeStyle, PolyMouseEvent} from './services/google-maps-types';
+export {LatLngBounds, LatLng, LatLngLiteral, MapTypeStyle, PolyMouseEvent, GoogleSymbol} from './services/google-maps-types';
 
 // core module
 // we explicitly export the module here to prevent this Ionic 2 bug:

--- a/packages/core/services/google-maps-types.ts
+++ b/packages/core/services/google-maps-types.ts
@@ -29,7 +29,7 @@ export interface Marker extends MVCObject {
   setTitle(title: string): void;
   setLabel(label: string|MarkerLabel): void;
   setDraggable(draggable: boolean): void;
-  setIcon(icon: string): void;
+  setIcon(icon: string|GoogleSymbol): void;
   setOpacity(opacity: number): void;
   setVisible(visible: boolean): void;
   setZIndex(zIndex: number): void;
@@ -44,12 +44,20 @@ export interface MarkerOptions {
   map?: GoogleMap;
   label?: string|MarkerLabel;
   draggable?: boolean;
-  icon?: string;
+  icon?: string|GoogleSymbol;
   opacity?: number;
   visible?: boolean;
   zIndex?: number;
   clickable: boolean;
   animation?: any;
+}
+
+export enum SymbolPath {
+  BACKWARD_CLOSED_ARROW,
+  BACKWARD_OPEN_ARROW,
+  CIRCLE,
+  FORWARD_CLOSED_ARROW,
+  FORWARD_OPEN_ARROW
 }
 
 export interface MarkerLabel {
@@ -58,6 +66,13 @@ export interface MarkerLabel {
   fontSize: string;
   fontWeight: string;
   text: string;
+}
+
+export interface Size {
+  width: number;
+  height: number;
+  widthUnit?: string;
+  heightUnit?: string;
 }
 
 export interface Circle extends MVCObject {
@@ -229,9 +244,9 @@ export interface Point {
 export interface GoogleSymbol {
   anchor?: Point;
   fillColor?: string;
-  fillOpacity?: string;
+  fillOpacity?: number;
   labelOrigin?: Point;
-  path?: string;
+  path?: string|SymbolPath;
   rotation?: number;
   scale?: number;
   strokeColor?: string;

--- a/packages/core/services/managers/info-window-manager.ts
+++ b/packages/core/services/managers/info-window-manager.ts
@@ -1,4 +1,4 @@
-import { Observable ,  Observer } from 'rxjs';
+import { Observable , Observer  } from 'rxjs';
 import {Injectable, NgZone} from '@angular/core';
 
 import {AgmInfoWindow} from '../../directives/info-window';

--- a/packages/core/services/managers/marker-manager.spec.ts
+++ b/packages/core/services/managers/marker-manager.spec.ts
@@ -3,8 +3,8 @@ import {TestBed, async, inject} from '@angular/core/testing';
 
 import {AgmMarker} from './../../directives/marker';
 import {GoogleMapsAPIWrapper} from './../google-maps-api-wrapper';
-import {Marker} from './../google-maps-types';
 import {MarkerManager} from './../managers/marker-manager';
+import {GoogleSymbol, SymbolPath} from './../google-maps-types';
 
 describe('MarkerManager', () => {
   beforeEach(() => {
@@ -98,10 +98,47 @@ describe('MarkerManager', () => {
                animation: undefined
              });
              const iconUrl = 'http://angular-maps.com/icon.png';
-             newMarker.iconUrl = iconUrl;
+             newMarker.icon = iconUrl;
              return markerManager.updateIcon(newMarker).then(
                  () => { expect(markerInstance.setIcon).toHaveBeenCalledWith(iconUrl); });
            })));
+
+           it('should update that marker via setIcon method when the marker icon changes',
+           async(inject(
+               [MarkerManager, GoogleMapsAPIWrapper],
+               (markerManager: MarkerManager, apiWrapper: GoogleMapsAPIWrapper) => {
+                 const newMarker = new AgmMarker(markerManager);
+                 newMarker.latitude = 34.4;
+                 newMarker.longitude = 22.3;
+                 newMarker.label = 'A';
+
+                 const markerInstance: any = {
+                  setMap: jest.fn(),
+                  setIcon: jest.fn()
+                 };
+                 (<jest.Mock>apiWrapper.createMarker).mockReturnValue(Promise.resolve(markerInstance));
+
+                 markerManager.addMarker(newMarker);
+                 expect(apiWrapper.createMarker).toHaveBeenCalledWith({
+                   position: {lat: 34.4, lng: 22.3},
+                   label: 'A',
+                   draggable: false,
+                   icon: undefined,
+                   opacity: 1,
+                   visible: true,
+                   zIndex: 1,
+                   title: undefined,
+                   clickable: true,
+                   animation: undefined
+                 });
+                 const icon: GoogleSymbol = {
+                   path: SymbolPath.FORWARD_OPEN_ARROW,
+                   rotation: 45
+                 };
+                 newMarker.icon = icon;
+                 return markerManager.updateIcon(newMarker).then(
+                     () => { expect(markerInstance.setIcon).toHaveBeenCalledWith(icon); });
+               })));
   });
 
   describe('set marker opacity', () => {

--- a/packages/core/services/managers/marker-manager.ts
+++ b/packages/core/services/managers/marker-manager.ts
@@ -47,7 +47,7 @@ export class MarkerManager {
   }
 
   updateIcon(marker: AgmMarker): Promise<void> {
-    return this._markers.get(marker).then((m: Marker) => m.setIcon(marker.iconUrl));
+    return this._markers.get(marker).then((m: Marker) => m.setIcon(marker.icon));
   }
 
   updateOpacity(marker: AgmMarker): Promise<void> {
@@ -81,7 +81,7 @@ export class MarkerManager {
       position: {lat: marker.latitude, lng: marker.longitude},
       label: marker.label,
       draggable: marker.draggable,
-      icon: marker.iconUrl,
+      icon: marker.icon,
       opacity: marker.opacity,
       visible: marker.visible,
       zIndex: marker.zIndex,

--- a/packages/js-marker-clusterer/services/managers/cluster-manager.spec.ts
+++ b/packages/js-marker-clusterer/services/managers/cluster-manager.spec.ts
@@ -3,7 +3,7 @@ import {TestBed, async, inject} from '@angular/core/testing';
 
 import {AgmMarker} from '../../../core/directives/marker';
 import {GoogleMapsAPIWrapper} from '../../../core/services/google-maps-api-wrapper';
-import {Marker} from '../../../core/services/google-maps-types';
+import {GoogleSymbol, SymbolPath} from '../../../core/services/google-maps-types';
 import {ClusterManager} from './cluster-manager';
 
 describe('ClusterManager', () => {
@@ -96,10 +96,46 @@ describe('ClusterManager', () => {
                clickable: true
              }, false);
              const iconUrl = 'http://angular-maps.com/icon.png';
-             newMarker.iconUrl = iconUrl;
+             newMarker.icon = iconUrl;
              return markerManager.updateIcon(newMarker).then(
                  () => { expect(markerInstance.setIcon).toHaveBeenCalledWith(iconUrl); });
            })));
+
+           it('should update that marker via setIcon method when the marker icon changes',
+           async(inject(
+               [ClusterManager, GoogleMapsAPIWrapper],
+               (markerManager: ClusterManager, apiWrapper: GoogleMapsAPIWrapper) => {
+                 const newMarker = new AgmMarker(markerManager);
+                 newMarker.latitude = 34.4;
+                 newMarker.longitude = 22.3;
+                 newMarker.label = 'A';
+
+                 const markerInstance: any = {
+                  setMap: jest.fn(),
+                  setIcon: jest.fn()
+                 };
+                 (<jest.Mock>apiWrapper.createMarker).mockReturnValue(Promise.resolve(markerInstance));
+
+                 markerManager.addMarker(newMarker);
+                 expect(apiWrapper.createMarker).toHaveBeenCalledWith({
+                   position: {lat: 34.4, lng: 22.3},
+                   label: 'A',
+                   draggable: false,
+                   icon: undefined,
+                   opacity: 1,
+                   visible: true,
+                   zIndex: 1,
+                   title: undefined,
+                   clickable: true
+                 }, false);
+                 const icon: GoogleSymbol = {
+                  path: SymbolPath.FORWARD_OPEN_ARROW,
+                  rotation: 45
+                };
+                newMarker.icon = icon;
+                 return markerManager.updateIcon(newMarker).then(
+                     () => { expect(markerInstance.setIcon).toHaveBeenCalledWith(icon); });
+               })));
   });
 
   describe('set marker opacity', () => {

--- a/packages/js-marker-clusterer/services/managers/cluster-manager.ts
+++ b/packages/js-marker-clusterer/services/managers/cluster-manager.ts
@@ -40,7 +40,7 @@ export class ClusterManager extends MarkerManager {
         },
         label: marker.label,
         draggable: marker.draggable,
-        icon: marker.iconUrl,
+        icon: marker.icon,
         opacity: marker.opacity,
         visible: marker.visible,
         zIndex: marker.zIndex,


### PR DESCRIPTION
* This will allow a user to create an agm-symbol-marker that is based on an
svg.
* A custom marker that is an svg type can also be rotated
* Changed the fillOpacity property on the GoogleSymbol interface to be a
number instead of a string