### PR TITLE
Add simple guide for adding circles to a map

### DIFF
--- a/docs/content/guides/circle.md
+++ b/docs/content/guides/circle.md
@@ -1,0 +1,26 @@
++++
+date = "2018-07-05T15:05:00+02:00"
+draft = false
+title = "Circles"
+
++++
+
+## Adding a Circle to the Map
+
+The `<agm-circle>` element will place a circle on the map.
+Here's an example:
+
+```html
+<agm-map [latitude]="59.326242" [longitude]="17.8419719" >
+  <agm-circle 
+    [latitude]="59.326242" 
+    [longitude]="17.8419719" 
+    [radius]="5000" 
+    [fillColor]="'red'" 
+    [circleDraggable]="true" 
+    [editable]="true">
+  </agm-circle>
+</agm-map>
+```
+
+To see an exhaustive list of all availabble properties see the [API DOCS](https://angular-maps.com/api-docs/agm-core/directives/AgmCircle.html).

--- a/packages/core/directives/marker.ts
+++ b/packages/core/directives/marker.ts
@@ -164,6 +164,9 @@ export class AgmMarker implements OnDestroy, OnChanges, AfterContentInit {
     if (typeof this.longitude === 'string') {
       this.longitude = Number(this.longitude);
     }
+    if (typeof this.latitude !== 'number' || typeof this.longitude !== 'number') {
+      return;
+    }
     if (!this._markerAddedToManger) {
       this._markerManager.addMarker(this);
       this._markerAddedToManger = true;

--- a/packages/core/directives/marker.ts
+++ b/packages/core/directives/marker.ts
@@ -158,8 +158,11 @@ export class AgmMarker implements OnDestroy, OnChanges, AfterContentInit {
 
   /** @internal */
   ngOnChanges(changes: {[key: string]: SimpleChange}) {
-    if (typeof this.latitude !== 'number' || typeof this.longitude !== 'number') {
-      return;
+    if (typeof this.latitude === 'string') {
+      this.latitude = Number(this.latitude);
+    }
+    if (typeof this.longitude === 'string') {
+      this.longitude = Number(this.longitude);
     }
     if (!this._markerAddedToManger) {
       this._markerManager.addMarker(this);


### PR DESCRIPTION
I've looked through the guides in the [documentation](https://angular-maps.com/guides/) and added a simple guide similar to the "Basic Info Windows" one.

I'm guessing the "Guides" section is relatively incomplete and there is a lot more to be added in the future so it might make sense to bundle the simple guides (e.g. basic info window, circle, ...) into one categorie "adding (simple) elements" or something similar.