### PR TITLE
feat(AgmFusionTablesLayer) Fusion Tables Layer

### DIFF
--- a/packages/core/core.module.ts
+++ b/packages/core/core.module.ts
@@ -9,6 +9,7 @@ import {AgmPolyline} from './directives/polyline';
 import {AgmPolylinePoint} from './directives/polyline-point';
 import {AgmKmlLayer} from './directives/kml-layer';
 import {AgmDataLayer} from './directives/data-layer';
+import {AgmFusionTablesLayer} from './directives/fusion-tables-layer';
 import {LazyMapsAPILoader} from './services/maps-api-loader/lazy-maps-api-loader';
 import {LAZY_MAPS_API_CONFIG, LazyMapsAPILoaderConfigLiteral} from './services/maps-api-loader/lazy-maps-api-loader';
 import {MapsAPILoader} from './services/maps-api-loader/maps-api-loader';
@@ -21,7 +22,7 @@ export function coreDirectives() {
   return [
     AgmMap, AgmMarker, AgmInfoWindow, AgmCircle, AgmRectangle,
     AgmPolygon, AgmPolyline, AgmPolylinePoint, AgmKmlLayer,
-    AgmDataLayer
+    AgmDataLayer, AgmFusionTablesLayer
   ];
 }
 

--- a/packages/core/directives.ts
+++ b/packages/core/directives.ts
@@ -4,6 +4,7 @@ export {AgmRectangle} from './directives/rectangle';
 export {AgmInfoWindow} from './directives/info-window';
 export {AgmKmlLayer} from './directives/kml-layer';
 export {AgmDataLayer} from './directives/data-layer';
+export {AgmFusionTablesLayer} from './directives/fusion-tables-layer';
 export {AgmMarker} from './directives/marker';
 export {AgmPolygon} from './directives/polygon';
 export {AgmPolyline} from './directives/polyline';

--- a/packages/core/directives/fusion-tables-layer.spec.ts
+++ b/packages/core/directives/fusion-tables-layer.spec.ts
@@ -1,0 +1,96 @@
+import {Component, ViewChild} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {Observable} from 'rxjs';
+
+import {AgmFusionTablesLayer} from './../directives/fusion-tables-layer';
+import {FusionTablesLayerOptions, FusionTablesMouseEvent} from './../services/google-maps-types';
+import {FusionTablesLayerManager} from './../services/managers/fusion-tables-layer-manager';
+
+@Component({
+  template:
+      `<agm-fusion-tables-layer [options]="options" (layerClick)="layerClick($event)"></agm-fusion-tables-layer>`
+})
+class ParentComponent {
+  @ViewChild(AgmFusionTablesLayer) fusionTablesLayer: AgmFusionTablesLayer;
+  options: FusionTablesLayerOptions = {query: {from: 'fusionTableId'}};
+  layerClick: any = jest.fn();
+}
+
+describe('AgmFusionTablesLayer', () => {
+  let fixture: ComponentFixture<ParentComponent>;
+  let comp: AgmFusionTablesLayer;
+  let manager: FusionTablesLayerManager;
+  let mockClick: (data: FusionTablesMouseEvent) => void;
+
+  beforeEach(() => {
+    TestBed
+        .configureTestingModule({
+          declarations: [ParentComponent, AgmFusionTablesLayer],
+          providers: [{
+            provide: FusionTablesLayerManager,
+            useValue: {
+              addFusionTablesLayer: jest.fn().mockReturnValue(Promise.resolve()),
+              deleteFusionTablesLayer: jest.fn().mockReturnValue(Promise.resolve()),
+              createEventObservable: jest.fn(
+                  (eventName: string, layer: AgmFusionTablesLayer) => new Observable(obs => {
+                    mockClick = data => obs.next(data);
+                  })),
+              updateFusionTablesLayerOptions: jest.fn().mockReturnValue(Promise.resolve()),
+            }
+          }]
+        })
+        .compileComponents();
+    fixture = TestBed.createComponent(ParentComponent);
+    comp = fixture.componentInstance.fusionTablesLayer;
+    fixture.detectChanges();
+    manager = TestBed.get(FusionTablesLayerManager);
+  });
+
+  describe('Creates a fusion tables layer', () => {
+    it('should create a fusion table layer', () => {
+      expect(comp).toBeTruthy();
+      expect(manager.addFusionTablesLayer).toBeCalledWith(comp);
+    });
+    it('should have the expected options passed in', () => {
+      expect(comp.options).toEqual({query: {from: 'fusionTableId'}});
+    });
+    it('should create click event listener', () => {
+      expect(manager.createEventObservable).toBeCalledWith('click', comp);
+    });
+    it('should only add to manager once', () => {
+      comp.ngOnInit();
+      expect(manager.addFusionTablesLayer).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Deleting a fusion tables layer', () => {
+    beforeEach(() => {
+      comp.ngOnDestroy();
+    });
+    it('should delete the fusion table', () => {
+      expect(manager.deleteFusionTablesLayer).toBeCalledWith(comp);
+    });
+  });
+
+  describe('Updating inputs', () => {
+    it('should update when options change', () => {
+      fixture.componentInstance.options = {query: {from: 'updatedFusionTableId'}};
+      fixture.detectChanges();
+      expect(manager.updateFusionTablesLayerOptions).toBeCalledWith(comp, {
+        query: {from: 'updatedFusionTableId'}
+      });
+    });
+  });
+
+  describe('Events', () => {
+    it('should not emit click when not clicked', () => {
+      expect(fixture.componentInstance.layerClick).toHaveBeenCalledTimes(0);
+    });
+    it('should output when layer is clicked', () => {
+      mockClick({row: {columnName: 'Amount', value: '15'}});
+      expect(fixture.componentInstance.layerClick).toBeCalledWith({
+        row: {columnName: 'Amount', value: '15'}
+      });
+    });
+  });
+});

--- a/packages/core/directives/fusion-tables-layer.ts
+++ b/packages/core/directives/fusion-tables-layer.ts
@@ -66,5 +66,10 @@ export class AgmFusionTablesLayer implements OnInit, OnDestroy, OnChanges {
     if (!this._addedToManager) {
       return;
     }
+
+    const optionsChange = changes['options'];
+    if (optionsChange) {
+      this._manager.updateFusionTablesLayerOptions(this, optionsChange.currentValue);
+    }
   }
 }

--- a/packages/core/directives/fusion-tables-layer.ts
+++ b/packages/core/directives/fusion-tables-layer.ts
@@ -1,0 +1,70 @@
+import {Directive, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges} from '@angular/core';
+import {Subscription} from 'rxjs';
+
+import {FusionTablesLayerOptions, FusionTablesMouseEvent} from './../services/google-maps-types';
+import {FusionTablesLayerManager} from './../services/managers/fusion-tables-layer-manager';
+
+let layerId = 0;
+
+@Directive({selector: 'agm-fusion-tables-layer'})
+export class AgmFusionTablesLayer implements OnInit, OnDestroy, OnChanges {
+  private _addedToManager: boolean = false;
+  private _id: string = (layerId++).toString();
+  private _subscriptions: Subscription[] = [];
+
+  /**
+   * This event is fired when a feature in the layer is clicked.
+   */
+  @Output()
+  layerClick: EventEmitter<FusionTablesMouseEvent> = new EventEmitter<FusionTablesMouseEvent>();
+
+  /**
+   * Fusion table layer options
+   */
+  @Input() options: FusionTablesLayerOptions;
+
+  constructor(private _manager: FusionTablesLayerManager) {}
+
+  ngOnInit() {
+    if (this._addedToManager) {
+      return;
+    }
+    this._manager.addFusionTablesLayer(this);
+    this._addedToManager = true;
+    this._addEventListeners();
+  }
+
+  private _addEventListeners() {
+    const listeners = [
+      {name: 'click', handler: (ev: FusionTablesMouseEvent) => this.layerClick.emit(ev)},
+    ];
+    listeners.forEach((obj) => {
+      const os = this._manager.createEventObservable(obj.name, this).subscribe(obj.handler);
+      this._subscriptions.push(os);
+    });
+  }
+
+  /** @internal */
+  id(): string {
+    return this._id;
+  }
+
+  /** @internal */
+  toString(): string {
+    return `AgmFusionTablesLayer-${this._id.toString()}`;
+  }
+
+  /** @internal */
+  ngOnDestroy() {
+    this._manager.deleteFusionTablesLayer(this);
+    // unsubscribe all registered observable subscriptions
+    this._subscriptions.forEach(s => s.unsubscribe());
+  }
+
+  /** @internal */
+  ngOnChanges(changes: SimpleChanges) {
+    if (!this._addedToManager) {
+      return;
+    }
+  }
+}

--- a/packages/core/directives/fusion-tables-layer.ts
+++ b/packages/core/directives/fusion-tables-layer.ts
@@ -4,12 +4,9 @@ import {Subscription} from 'rxjs';
 import {FusionTablesLayerOptions, FusionTablesMouseEvent} from './../services/google-maps-types';
 import {FusionTablesLayerManager} from './../services/managers/fusion-tables-layer-manager';
 
-let layerId = 0;
-
 @Directive({selector: 'agm-fusion-tables-layer'})
 export class AgmFusionTablesLayer implements OnInit, OnDestroy, OnChanges {
   private _addedToManager: boolean = false;
-  private _id: string = (layerId++).toString();
   private _subscriptions: Subscription[] = [];
 
   /**
@@ -42,16 +39,6 @@ export class AgmFusionTablesLayer implements OnInit, OnDestroy, OnChanges {
       const os = this._manager.createEventObservable(obj.name, this).subscribe(obj.handler);
       this._subscriptions.push(os);
     });
-  }
-
-  /** @internal */
-  id(): string {
-    return this._id;
-  }
-
-  /** @internal */
-  toString(): string {
-    return `AgmFusionTablesLayer-${this._id.toString()}`;
   }
 
   /** @internal */

--- a/packages/core/directives/map.ts
+++ b/packages/core/directives/map.ts
@@ -15,6 +15,7 @@ import {PolygonManager} from '../services/managers/polygon-manager';
 import {PolylineManager} from '../services/managers/polyline-manager';
 import {KmlLayerManager} from './../services/managers/kml-layer-manager';
 import {DataLayerManager} from './../services/managers/data-layer-manager';
+import {FusionTablesLayerManager} from './../services/managers/fusion-tables-layer-manager';
 
 /**
  * AgmMap renders a Google Map.
@@ -43,7 +44,7 @@ import {DataLayerManager} from './../services/managers/data-layer-manager';
   selector: 'agm-map',
   providers: [
     GoogleMapsAPIWrapper, MarkerManager, InfoWindowManager, CircleManager, RectangleManager,
-    PolylineManager, PolygonManager, KmlLayerManager, DataLayerManager
+    PolylineManager, PolygonManager, KmlLayerManager, DataLayerManager, FusionTablesLayerManager
   ],
   host: {
     // todo: deprecated - we will remove it with the next version

--- a/packages/core/services.ts
+++ b/packages/core/services.ts
@@ -7,6 +7,7 @@ export {PolygonManager} from './services/managers/polygon-manager';
 export {PolylineManager} from './services/managers/polyline-manager';
 export {KmlLayerManager} from './services/managers/kml-layer-manager';
 export {DataLayerManager} from './services/managers/data-layer-manager';
+export {FusionTablesLayerManager} from './services/managers/fusion-tables-layer-manager';
 export {GoogleMapsScriptProtocol, LAZY_MAPS_API_CONFIG, LazyMapsAPILoader, LazyMapsAPILoaderConfigLiteral} from './services/maps-api-loader/lazy-maps-api-loader';
 export {MapsAPILoader} from './services/maps-api-loader/maps-api-loader';
 export {NoOpMapsAPILoader} from './services/maps-api-loader/noop-maps-api-loader';

--- a/packages/core/services/google-maps-api-wrapper.ts
+++ b/packages/core/services/google-maps-api-wrapper.ts
@@ -102,6 +102,18 @@ export class GoogleMapsAPIWrapper {
   }
 
   /**
+   * Creates a new google.map.FusionTablesLayer for the current map
+   */
+  createFusionTablesLayer(options?: mapTypes.FusionTablesLayerOptions): Promise<mapTypes.FusionTablesLayer> {
+    console.log('createFusionTablesLayer', options);
+    return this._map.then(m => {
+      let layer = new google.maps.FusionTablesLayer(options);
+      layer.setMap(m);
+      return layer;
+    });
+  }
+
+  /**
    * Determines if given coordinates are insite a Polygon path.
    */
   containsLocation(latLng: mapTypes.LatLngLiteral, polygon: mapTypes.Polygon): Promise<boolean> {

--- a/packages/core/services/google-maps-api-wrapper.ts
+++ b/packages/core/services/google-maps-api-wrapper.ts
@@ -105,7 +105,6 @@ export class GoogleMapsAPIWrapper {
    * Creates a new google.map.FusionTablesLayer for the current map
    */
   createFusionTablesLayer(options?: mapTypes.FusionTablesLayerOptions): Promise<mapTypes.FusionTablesLayer> {
-    console.log('createFusionTablesLayer', options);
     return this._map.then(m => {
       let layer = new google.maps.FusionTablesLayer(options);
       layer.setMap(m);

--- a/packages/core/services/google-maps-types.ts
+++ b/packages/core/services/google-maps-types.ts
@@ -428,6 +428,61 @@ export interface Data extends MVCObject {
   /* tslint:enable */
 }
 
+export interface FusionTablesLayer extends MVCObject {
+  getMap(): GoogleMap;
+  setMap(map: GoogleMap): void;
+  setOptions(options: FusionTablesLayerOptions): void;
+}
+
+export interface FusionTablesLayerOptions {
+  clickable?: boolean;
+  heatmap?: FusionTablesHeatmap;
+  map?: GoogleMap;
+  query?: FusionTablesQuery;
+  styles?: FusionTablesStyle[];
+  suppressInfoWindows?: boolean;
+}
+
+export interface FusionTablesHeatmap {
+  enabled?: boolean;
+}
+
+export interface FusionTablesQuery {
+  from: string;
+  limit?: number;
+  offset?: number;
+  orderBy?: string;
+  select?: string;
+  where?: string;
+}
+
+export interface FusionTablesStyle {
+  markerOptions?: FusionTablesMarkerOptions;
+  polygonOptions?: FusionTablesPolygonOptions;
+  polylineOptions?: FusionTablesPolylineOptions;
+  where?: string;
+}
+
+export interface FusionTablesMarkerOptions {
+  iconName: string;
+}
+
+export type FusionTablesPolygonOptions = Pick<PolygonOptions, 'fillColor' | 'fillOpacity' | 'strokeColor'| 'strokeOpacity' | 'strokeWeight'>;
+
+export type FusionTablesPolylineOptions = Pick<PolylineOptions,  'strokeColor'| 'strokeOpacity' | 'strokeWeight'>;
+
+export interface FusionTablesMouseEvent {
+  infoWindowHtml?: string;
+  latLng?: LatLng;
+  pixelOffset?: Size;
+  row?: FusionTablesCell;
+}
+
+export interface FusionTablesCell {
+  columnName?: string;
+  value?: string;
+}
+
 export interface Feature extends MVCObject {
   id?: number|string|undefined;
   geometry: Geometry;

--- a/packages/core/services/managers/fusion-tables-layer-manager.spec.ts
+++ b/packages/core/services/managers/fusion-tables-layer-manager.spec.ts
@@ -64,6 +64,40 @@ describe('FusionTablesLayerManager', () => {
            }));
   });
 
+  describe('Updates options for an existing fusion table layer', () => {
+    it('should setOptions on the layer',
+       inject(
+           [FusionTablesLayerManager, GoogleMapsAPIWrapper],
+           (manager: FusionTablesLayerManager, apiWrapper: GoogleMapsAPIWrapper) => {
+             const newLayer = new AgmFusionTablesLayer(manager);
+             newLayer.options = {
+               query: {
+                 from: '1ertEwm-1bMBhpEwHhtNYT47HQ9k2ki_6sRa-UQ',
+               },
+             };
+             const layerInstance: any = {setOptions: jest.fn()};
+             (<jest.Mock>apiWrapper.createFusionTablesLayer)
+                 .mockReturnValue(Promise.resolve(layerInstance));
+
+             manager.addFusionTablesLayer(newLayer);
+             manager
+                 .updateFusionTablesLayerOptions(newLayer, {
+                   query: {from: '1ertEwm-1bMBhpEwHhtNYT47HQ9k2ki_6sRa-UQ'},
+                   styles: [
+                     {polygonOptions: {fillColor: '#00FF00', fillOpacity: 0.3}},
+                   ],
+                 })
+                 .then(() => {
+                   expect(layerInstance.setOptions).toHaveBeenCalledWith({
+                     query: {from: '1ertEwm-1bMBhpEwHhtNYT47HQ9k2ki_6sRa-UQ'},
+                     styles: [
+                       {polygonOptions: {fillColor: '#00FF00', fillOpacity: 0.3}},
+                     ],
+                   });
+                 });
+           }));
+  });
+
   describe('Create event listener for a layer', () => {
     it('should add a listener on the layer',
        inject(

--- a/packages/core/services/managers/fusion-tables-layer-manager.spec.ts
+++ b/packages/core/services/managers/fusion-tables-layer-manager.spec.ts
@@ -1,0 +1,88 @@
+import {NgZone} from '@angular/core';
+import {inject, TestBed} from '@angular/core/testing';
+
+import {AgmFusionTablesLayer} from './../../directives/fusion-tables-layer';
+import {GoogleMapsAPIWrapper} from './../google-maps-api-wrapper';
+import {FusionTablesLayerManager} from './../managers/fusion-tables-layer-manager';
+
+describe('FusionTablesLayerManager', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: NgZone, useFactory: () => new NgZone({enableLongStackTrace: true})},
+        FusionTablesLayerManager,
+        {provide: GoogleMapsAPIWrapper, useValue: {createFusionTablesLayer: jest.fn()}}
+      ]
+    });
+  });
+
+  describe('Create a fusion table layer', () => {
+    it('should call the mapsApiWrapper when creating a new fusion tables layer',
+       inject(
+           [FusionTablesLayerManager, GoogleMapsAPIWrapper],
+           (manager: FusionTablesLayerManager, apiWrapper: GoogleMapsAPIWrapper) => {
+             const newLayer = new AgmFusionTablesLayer(manager);
+             newLayer.options = {
+               query: {
+                 select: 'geometry',
+                 from: '1ertEwm-1bMBhpEwHhtNYT47HQ9k2ki_6sRa-UQ',
+               },
+             };
+             manager.addFusionTablesLayer(newLayer);
+
+             expect(apiWrapper.createFusionTablesLayer).toHaveBeenCalledWith({
+               query: {
+                 select: 'geometry',
+                 from: '1ertEwm-1bMBhpEwHhtNYT47HQ9k2ki_6sRa-UQ',
+               },
+             });
+           }));
+  });
+
+  describe('Delete a fusion table layer', () => {
+    it('should set the map to null when deleting an existing layer',
+       inject(
+           [FusionTablesLayerManager, GoogleMapsAPIWrapper],
+           (manager: FusionTablesLayerManager, apiWrapper: GoogleMapsAPIWrapper) => {
+             const newLayer = new AgmFusionTablesLayer(manager);
+             newLayer.options = {
+               query: {
+                 from: '1ertEwm-1bMBhpEwHhtNYT47HQ9k2ki_6sRa-UQ',
+               },
+               styles: [
+                 {polygonOptions: {fillColor: '#00FF00', fillOpacity: 0.3}},
+               ],
+             };
+             const layerInstance: any = {setMap: jest.fn()};
+             (<jest.Mock>apiWrapper.createFusionTablesLayer)
+                 .mockReturnValue(Promise.resolve(layerInstance));
+
+             manager.addFusionTablesLayer(newLayer);
+             manager.deleteFusionTablesLayer(newLayer).then(() => {
+               expect(layerInstance.setMap).toHaveBeenCalledWith(null);
+             });
+           }));
+  });
+
+  describe('Create event listener for a layer', () => {
+    it('should add a listener on the layer',
+       inject(
+           [FusionTablesLayerManager, GoogleMapsAPIWrapper],
+           (manager: FusionTablesLayerManager, apiWrapper: GoogleMapsAPIWrapper) => {
+             const newLayer = new AgmFusionTablesLayer(manager);
+             newLayer.options = {
+               query: {
+                 from: '1ertEwm-1bMBhpEwHhtNYT47HQ9k2ki_6sRa-UQ',
+               },
+             };
+             const layerInstance: any = {addListener: jest.fn()};
+             (<jest.Mock>apiWrapper.createFusionTablesLayer)
+                 .mockReturnValue(Promise.resolve(layerInstance));
+
+             manager.addFusionTablesLayer(newLayer);
+             manager.createEventObservable('click', newLayer).subscribe(() => {
+               expect(layerInstance.addListener).toBeCalledWith('click');
+             });
+           }));
+  });
+});

--- a/packages/core/services/managers/fusion-tables-layer-manager.ts
+++ b/packages/core/services/managers/fusion-tables-layer-manager.ts
@@ -22,11 +22,11 @@ export class FusionTablesLayerManager {
    */
   addFusionTablesLayer(layer: AgmFusionTablesLayer) {
     const newLayer = this._wrapper.createFusionTablesLayer(layer.options);
-    this._layers.set(layer, newLayer);
+    return this._layers.set(layer, newLayer);
   }
 
   deleteFusionTablesLayer(layer: AgmFusionTablesLayer) {
-    this._layers.get(layer).then(l => {
+    return this._layers.get(layer).then(l => {
       l.setMap(null);
       this._layers.delete(layer);
     });

--- a/packages/core/services/managers/fusion-tables-layer-manager.ts
+++ b/packages/core/services/managers/fusion-tables-layer-manager.ts
@@ -1,0 +1,45 @@
+import {Injectable, NgZone} from '@angular/core';
+import {Observable, Observer} from 'rxjs';
+
+import {AgmFusionTablesLayer} from './../../directives/fusion-tables-layer';
+import {GoogleMapsAPIWrapper} from './../google-maps-api-wrapper';
+import {FusionTablesLayer} from './../google-maps-types';
+
+declare var google: any;
+
+/**
+ * Manages all Fusion Tables Layers for a Google Map instance.
+ */
+@Injectable()
+export class FusionTablesLayerManager {
+  private _layers: Map<AgmFusionTablesLayer, Promise<FusionTablesLayer>> =
+      new Map<AgmFusionTablesLayer, Promise<FusionTablesLayer>>();
+
+  constructor(private _wrapper: GoogleMapsAPIWrapper, private _zone: NgZone) {}
+
+  /**
+   * Adds a new Fusion Tables Layer to the map.
+   */
+  addFusionTablesLayer(layer: AgmFusionTablesLayer) {
+    const newLayer = this._wrapper.createFusionTablesLayer(layer.options);
+    this._layers.set(layer, newLayer);
+  }
+
+  deleteFusionTablesLayer(layer: AgmFusionTablesLayer) {
+    this._layers.get(layer).then(l => {
+      l.setMap(null);
+      this._layers.delete(layer);
+    });
+  }
+
+  /**
+   * Creates a Google Maps event listener for the given FusionTablesLayer as an Observable
+   */
+  createEventObservable<T>(eventName: string, layer: AgmFusionTablesLayer): Observable<T> {
+    return new Observable((observer: Observer<T>) => {
+      this._layers.get(layer).then((d: FusionTablesLayer) => {
+        d.addListener(eventName, (e: T) => this._zone.run(() => observer.next(e)));
+      });
+    });
+  }
+}

--- a/packages/core/services/managers/fusion-tables-layer-manager.ts
+++ b/packages/core/services/managers/fusion-tables-layer-manager.ts
@@ -3,12 +3,12 @@ import {Observable, Observer} from 'rxjs';
 
 import {AgmFusionTablesLayer} from './../../directives/fusion-tables-layer';
 import {GoogleMapsAPIWrapper} from './../google-maps-api-wrapper';
-import {FusionTablesLayer} from './../google-maps-types';
+import {FusionTablesLayer, FusionTablesLayerOptions} from './../google-maps-types';
 
 declare var google: any;
 
 /**
- * Manages all Fusion Tables Layers for a Google Map instance.
+ * Manages all FusionTablesLayers for a Google Map instance.
  */
 @Injectable()
 export class FusionTablesLayerManager {
@@ -18,13 +18,16 @@ export class FusionTablesLayerManager {
   constructor(private _wrapper: GoogleMapsAPIWrapper, private _zone: NgZone) {}
 
   /**
-   * Adds a new Fusion Tables Layer to the map.
+   * Adds a new FusionTablesLayer to the map.
    */
   addFusionTablesLayer(layer: AgmFusionTablesLayer) {
     const newLayer = this._wrapper.createFusionTablesLayer(layer.options);
     return this._layers.set(layer, newLayer);
   }
 
+  /**
+   * Deletes an existing FusionTablesLayer
+   */
   deleteFusionTablesLayer(layer: AgmFusionTablesLayer) {
     return this._layers.get(layer).then(l => {
       l.setMap(null);
@@ -40,6 +43,15 @@ export class FusionTablesLayerManager {
       this._layers.get(layer).then((d: FusionTablesLayer) => {
         d.addListener(eventName, (e: T) => this._zone.run(() => observer.next(e)));
       });
+    });
+  }
+
+  /**
+   * Updates the options for a FusionTablesLayer
+   */
+  updateFusionTablesLayerOptions(layer: AgmFusionTablesLayer, options: FusionTablesLayerOptions) {
+    return this._layers.get(layer).then(l => {
+      l.setOptions(options);
     });
   }
 }


### PR DESCRIPTION
Adds support fusion tables through angular-google-maps.

**Additions**
Added a new `agm-fusion-tables-layer` directive that accepts fusion tables layer config.

**Usage**
```typescript
import { Component } from '@angular/core';

@Component({
  selector: 'app-component',
  template: `
    <agm-map>
        <agm-fusion-tables-layer [options]="options"></agm-fusion-tables-layer>
    </agm-map>
  `,
})
export class MyComponent {
  options = {
    query: {
      select: 'location',
      from: '1xWyeuAhIFK_aED1ikkQEGmR8mINSCJO9Vq-BPQ',
    },
    heatmap: { enabled: true },
  };
}
```

Renders the following

![screen shot 2018-07-09 at 5 07 53 pm](https://user-images.githubusercontent.com/19592095/42437947-bef6086e-839d-11e8-9028-d69a412ca76d.png)

****

**Ticket**
Closes #1452