### PR TITLE
include marker instance in markerClick emitter

### DIFF
--- a/packages/core/directives/marker.ts
+++ b/packages/core/directives/marker.ts
@@ -113,7 +113,7 @@ export class AgmMarker implements OnDestroy, OnChanges, AfterContentInit {
   /**
    * This event emitter gets emitted when the user clicks on the marker.
    */
-  @Output() markerClick: EventEmitter<void> = new EventEmitter<void>();
+  @Output() markerClick: EventEmitter<AgmMarker> = new EventEmitter<AgmMarker>();
 
   /**
    * This event is fired when the user rightclicks on the marker.
@@ -215,7 +215,7 @@ export class AgmMarker implements OnDestroy, OnChanges, AfterContentInit {
       if (this.openInfoWindow) {
         this.infoWindow.forEach(infoWindow => infoWindow.open());
       }
-      this.markerClick.emit(null);
+      this.markerClick.emit(this);
     });
     this._observableSubscriptions.push(cs);
 


### PR DESCRIPTION
feat AgmMarker: include marker instance in markerClick emitter

it is usefull to be able to work directly with the marker clicked in the event handler, instead of writing extra code to determine it