### PR TITLE
Resolve loader.load method with google.maps

### DIFF
--- a/packages/core/services/fit-bounds.spec.ts
+++ b/packages/core/services/fit-bounds.spec.ts
@@ -11,14 +11,10 @@ describe('FitBoundsService', () => {
   let latLngBoundsExtend: jest.Mock;
 
   beforeEach(fakeAsync(() => {
-    loader = {
-      load: jest.fn().mockReturnValue(Promise.resolve())
-    };
-
     latLngBoundsConstructs = 0;
     latLngBoundsExtend = jest.fn();
 
-    (<any>window).google = {
+    const google = {
       maps: {
         LatLngBounds: class LatLngBounds {
           extend: jest.Mock = latLngBoundsExtend;
@@ -28,6 +24,10 @@ describe('FitBoundsService', () => {
           }
         }
       }
+    };
+
+    loader = {
+      load: jest.fn().mockReturnValue(Promise.resolve(google.maps))
     };
 
     TestBed.configureTestingModule({

--- a/packages/core/services/fit-bounds.ts
+++ b/packages/core/services/fit-bounds.ts
@@ -39,7 +39,7 @@ export class FitBoundsService {
   protected readonly bounds$: Observable<LatLngBounds>;
   protected readonly _boundsChangeSampleTime$ = new BehaviorSubject<number>(200);
   protected readonly _includeInBounds$ = new BehaviorSubject<BoundsMap>(new Map<string, LatLng | LatLngLiteral>());
-  protected googleMaps;
+  protected googleMaps: any;
 
   constructor(loader: MapsAPILoader) {
     this.bounds$ = from(loader.load()).pipe(

--- a/packages/core/services/fit-bounds.ts
+++ b/packages/core/services/fit-bounds.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable, from, timer } from 'rxjs';
 import {
   flatMap,
+  tap,
   map,
   skipWhile,
   sample,
@@ -38,9 +39,11 @@ export class FitBoundsService {
   protected readonly bounds$: Observable<LatLngBounds>;
   protected readonly _boundsChangeSampleTime$ = new BehaviorSubject<number>(200);
   protected readonly _includeInBounds$ = new BehaviorSubject<BoundsMap>(new Map<string, LatLng | LatLngLiteral>());
+  protected googleMaps;
 
   constructor(loader: MapsAPILoader) {
     this.bounds$ = from(loader.load()).pipe(
+      tap(googleMaps => this.googleMaps = googleMaps),
       flatMap(() => this._includeInBounds$),
       sample(
         this._boundsChangeSampleTime$.pipe(switchMap(time => timer(0, time)))
@@ -53,7 +56,7 @@ export class FitBoundsService {
   private _generateBounds(
     includeInBounds: Map<string, LatLng | LatLngLiteral>
   ) {
-    const bounds = new google.maps.LatLngBounds() as LatLngBounds;
+    const bounds = new this.googleMaps.LatLngBounds() as LatLngBounds;
     includeInBounds.forEach(b => bounds.extend(b));
     return bounds;
   }

--- a/packages/core/services/google-maps-api-wrapper.ts
+++ b/packages/core/services/google-maps-api-wrapper.ts
@@ -25,8 +25,8 @@ export class GoogleMapsAPIWrapper {
 
   createMap(el: HTMLElement, mapOptions: mapTypes.MapOptions): Promise<void> {
     return this._zone.runOutsideAngular( () => {
-      return this._loader.load().then(() => {
-        const map = new google.maps.Map(el, mapOptions);
+      return this._loader.load().then(googleMaps => {
+        const map = new googleMaps.Map(el, mapOptions);
         this._mapResolver(<mapTypes.GoogleMap>map);
         return;
       });

--- a/packages/core/services/maps-api-loader/lazy-maps-api-loader.ts
+++ b/packages/core/services/maps-api-loader/lazy-maps-api-loader.ts
@@ -98,7 +98,7 @@ export class LazyMapsAPILoader extends MapsAPILoader {
     const window = <any>this._windowRef.getNativeWindow();
     if (window.google && window.google.maps) {
       // Google maps already loaded on the page.
-      return Promise.resolve();
+      return Promise.resolve(window.google.maps);
     }
 
     if (this._scriptLoadingPromise) {
@@ -125,8 +125,9 @@ export class LazyMapsAPILoader extends MapsAPILoader {
 
   private _assignScriptLoadingPromise(scriptElem: HTMLElement) {
     this._scriptLoadingPromise = new Promise<void>((resolve: Function, reject: Function) => {
-      (<any>this._windowRef.getNativeWindow())[this.callbackName] = () => {
-        resolve();
+      const window = <any>this._windowRef.getNativeWindow();
+      window[this.callbackName] = () => {
+        resolve(window.google.maps);
       };
 
       scriptElem.onerror = (error: Event) => {

--- a/packages/core/services/maps-api-loader/maps-api-loader.ts
+++ b/packages/core/services/maps-api-loader/maps-api-loader.ts
@@ -2,5 +2,5 @@ import {Injectable} from '@angular/core';
 
 @Injectable()
 export abstract class MapsAPILoader {
-  abstract load(): Promise<void>;
+  abstract load(): Promise<any>;
 }

--- a/packages/core/services/maps-api-loader/noop-maps-api-loader.ts
+++ b/packages/core/services/maps-api-loader/noop-maps-api-loader.ts
@@ -11,6 +11,6 @@ export class NoOpMapsAPILoader implements MapsAPILoader {
       throw new Error(
           'Google Maps API not loaded on page. Make sure window.google.maps is available!');
     }
-    return Promise.resolve();
+    return Promise.resolve((<any>window).google.maps);
   }
 }


### PR DESCRIPTION
#1517 -- this makes changes to resolve the loaders with `google.maps` as appropriate. `google.maps` is still available globally once it is loaded, so this should be fully backwards-compatible.