### PR TITLE
test(NoOpMapsAPILoader) add coverage

### DIFF
--- a/packages/core/services/maps-api-loader/noop-maps-api-loader.spec.ts
+++ b/packages/core/services/maps-api-loader/noop-maps-api-loader.spec.ts
@@ -1,0 +1,45 @@
+import {inject, TestBed} from '@angular/core/testing';
+
+import {WindowRef} from '../../utils/browser-globals';
+import {MapsAPILoader} from './maps-api-loader';
+import {NoOpMapsAPILoader} from './noop-maps-api-loader';
+
+describe('Service: NoOpMapsAPILoader', () => {
+  let windowRef: WindowRef;
+  let windowObj: any;
+
+  beforeEach(() => {
+    windowObj = {};
+    windowRef = <WindowRef>{getNativeWindow: jest.fn().mockReturnValue(windowObj)};
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: MapsAPILoader, useClass: NoOpMapsAPILoader},
+        {provide: WindowRef, useValue: windowRef}
+      ]
+    });
+  });
+
+  it('should resolve when google maps exist on the window', () => {
+    inject([MapsAPILoader], (loader: NoOpMapsAPILoader) => {
+      windowObj.google = {maps: {}};
+      expect(loader.load()).toEqual(Promise.resolve());
+    });
+  });
+
+  it('should throw an error when window.google does not exist', () => {
+    inject([MapsAPILoader], (loader: NoOpMapsAPILoader) => {
+      expect(loader.load)
+          .toThrowError(new Error(
+              'Google Maps API not loaded on page. Make sure window.google.maps is available!'));
+    });
+  });
+
+  it('should throw an error when window.google.maps does not exist', () => {
+    inject([MapsAPILoader], (loader: NoOpMapsAPILoader) => {
+      windowObj.google = {};
+      expect(loader.load)
+          .toThrowError(new Error(
+              'Google Maps API not loaded on page. Make sure window.google.maps is available!'));
+    });
+  });
+});

--- a/packages/core/services/maps-api-loader/noop-maps-api-loader.spec.ts
+++ b/packages/core/services/maps-api-loader/noop-maps-api-loader.spec.ts
@@ -29,8 +29,8 @@ describe('Service: NoOpMapsAPILoader', () => {
   it('should throw an error when window.google does not exist', () => {
     inject([MapsAPILoader], (loader: NoOpMapsAPILoader) => {
       expect(loader.load)
-          .toThrowError(new Error(
-              'Google Maps API not loaded on page. Make sure window.google.maps is available!'));
+          .toThrowError(
+              'Google Maps API not loaded on page. Make sure window.google.maps is available!');
     });
   });
 
@@ -38,8 +38,8 @@ describe('Service: NoOpMapsAPILoader', () => {
     inject([MapsAPILoader], (loader: NoOpMapsAPILoader) => {
       windowObj.google = {};
       expect(loader.load)
-          .toThrowError(new Error(
-              'Google Maps API not loaded on page. Make sure window.google.maps is available!'));
+          .toThrowError(
+              'Google Maps API not loaded on page. Make sure window.google.maps is available!');
     });
   });
 });

--- a/packages/core/services/maps-api-loader/noop-maps-api-loader.ts
+++ b/packages/core/services/maps-api-loader/noop-maps-api-loader.ts
@@ -1,3 +1,4 @@
+import {WindowRef} from '../../utils/browser-globals';
 import {MapsAPILoader} from './maps-api-loader';
 
 /**
@@ -6,8 +7,15 @@ import {MapsAPILoader} from './maps-api-loader';
  * It's important that the Google Maps API script gets loaded first on the page.
  */
 export class NoOpMapsAPILoader implements MapsAPILoader {
+  protected _windowRef: WindowRef;
+
+  constructor(w: WindowRef) {
+    this._windowRef = w;
+  }
+
   load(): Promise<void> {
-    if (!(<any>window).google || !(<any>window).google.maps) {
+    const window = <any>this._windowRef.getNativeWindow();
+    if (!window.google || !window.google.maps) {
       throw new Error(
           'Google Maps API not loaded on page. Make sure window.google.maps is available!');
     }


### PR DESCRIPTION
Add missing test coverage for `NoOpMapsAPILoader`.

Use `WindowRef` in the same manner as the Lazy loader.