### PR TITLE
fix(1509): SystemJS module resolution failure.

### DIFF
--- a/packages/core/core.module.ts
+++ b/packages/core/core.module.ts
@@ -13,7 +13,7 @@ import {LazyMapsAPILoader} from './services/maps-api-loader/lazy-maps-api-loader
 import {LAZY_MAPS_API_CONFIG, LazyMapsAPILoaderConfigLiteral} from './services/maps-api-loader/lazy-maps-api-loader';
 import {MapsAPILoader} from './services/maps-api-loader/maps-api-loader';
 import {BROWSER_GLOBALS_PROVIDERS} from './utils/browser-globals';
-import {AgmFitBounds} from '@agm/core/directives/fit-bounds';
+import {AgmFitBounds} from './directives/fit-bounds';
 
 /**
  * @internal


### PR DESCRIPTION
fix(agm): AgmFitBounds was being referenced as an absolute path. Causing module resolver SystemJS to fail.

fixes #1509