### PR TITLE
Fix: _updateBounds not creating newBounds object

### DIFF
--- a/packages/core/directives/map.ts
+++ b/packages/core/directives/map.ts
@@ -476,7 +476,7 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
 
   protected _updateBounds(bounds: LatLngBounds|LatLngBoundsLiteral) {
     if (this._isLatLngBoundsLiteral(bounds) && google && google.maps) {
-      const newBounds = <LatLngBounds>google.maps.LatLngBounds();
+      const newBounds = new google.maps.LatLngBounds();
       newBounds.union(bounds);
       bounds = newBounds;
     }


### PR DESCRIPTION
A new LatLngBounds object is required to use the union method immediately afterwards