### PR TITLE
feat(GoogleMapsAPILoader): change default API version

### DIFF
--- a/packages/core/services/maps-api-loader/lazy-maps-api-loader.spec.ts
+++ b/packages/core/services/maps-api-loader/lazy-maps-api-loader.spec.ts
@@ -55,7 +55,7 @@ describe('Service: LazyMapsAPILoader', () => {
       expect(scriptElem.src).toBeDefined();
       expect(scriptElem.id).toEqual('agmGoogleMapsApiScript');
       expect(scriptElem.src).toContain('https://maps.googleapis.com/maps/api/js');
-      expect(scriptElem.src).toContain('v=3');
+      expect(scriptElem.src).toContain('v=quarterly');
       expect(scriptElem.src).toContain('callback=agmLazyMapsAPILoader');
       expect(doc.body.appendChild).toHaveBeenCalledWith(scriptElem);
   }));

--- a/packages/core/services/maps-api-loader/lazy-maps-api-loader.ts
+++ b/packages/core/services/maps-api-loader/lazy-maps-api-loader.ts
@@ -154,7 +154,7 @@ export class LazyMapsAPILoader extends MapsAPILoader {
 
     const hostAndPath: string = this._config.hostAndPath || 'maps.googleapis.com/maps/api/js';
     const queryParams: {[key: string]: string | Array<string>} = {
-      v: this._config.apiVersion || '3',
+      v: this._config.apiVersion || 'quarterly',
       callback: callbackName,
       key: this._config.apiKey,
       client: this._config.clientId,


### PR DESCRIPTION
Fixes #1573

This changes the default Google Maps API version to `quarterly`.

More details about the new versioning schema here: https://developers.google.com/maps/documentation/javascript/versions