### PR TITLE
Bugfix: Load on Angular 7 SSR

### DIFF
--- a/packages/core/directives/map.ts
+++ b/packages/core/directives/map.ts
@@ -1,4 +1,5 @@
-import { Component, ElementRef, EventEmitter, OnChanges, OnDestroy, OnInit, SimpleChanges, Input, Output } from '@angular/core';
+import {Component, ElementRef, EventEmitter, OnChanges, OnDestroy, OnInit, SimpleChanges, Input, Output, Inject, PLATFORM_ID} from '@angular/core';
+import {isPlatformBrowser} from '@angular/common';
 import {Subscription} from 'rxjs';
 
 import {MouseEvent} from '../map-types';
@@ -323,13 +324,23 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
    */
   @Output() mapReady: EventEmitter<any> = new EventEmitter<any>();
 
-  constructor(private _elem: ElementRef, private _mapsWrapper: GoogleMapsAPIWrapper, protected _fitBoundsService: FitBoundsService) {}
+  /**
+   * This checks the platform we are running in, and, only initMapInstance
+   * if isBrowser.
+   */
+  isBrowser: boolean;
+
+  constructor(private _elem: ElementRef, private _mapsWrapper: GoogleMapsAPIWrapper, protected _fitBoundsService: FitBoundsService, @Inject(PLATFORM_ID) platformId: Object) {
+    this.isBrowser = isPlatformBrowser(platformId);
+  }
 
   /** @internal */
   ngOnInit() {
-    // todo: this should be solved with a new component and a viewChild decorator
-    const container = this._elem.nativeElement.querySelector('.agm-map-container-inner');
-    this._initMapInstance(container);
+    if (this.isBrowser) {
+      // todo: this should be solved with a new component and a viewChild decorator
+      const container = this._elem.nativeElement.querySelector('.agm-map-container-inner');
+      this._initMapInstance(container);
+    }
   }
 
   private _initMapInstance(el: HTMLElement) {

--- a/packages/core/services/maps-api-loader/lazy-maps-api-loader.ts
+++ b/packages/core/services/maps-api-loader/lazy-maps-api-loader.ts
@@ -95,7 +95,14 @@ export class LazyMapsAPILoader extends MapsAPILoader {
   }
 
   load(): Promise<void> {
-    const window = <any>this._windowRef.getNativeWindow();
+    let window;
+    try {
+      window = <any>this._windowRef.getNativeWindow();
+    } catch (e) {
+      // We don't have window, so, ignore loading.
+      return Promise.resolve();
+    }
+
     if (window.google && window.google.maps) {
       // Google maps already loaded on the page.
       return Promise.resolve();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "es2015",
+        "module": "commonjs",
         "target": "es5",
         "noImplicitAny": true,
         "experimentalDecorators": true,
@@ -11,7 +11,7 @@
         "removeComments": false,
         "moduleResolution": "node",
         "declaration": true,
-        "allowSyntheticDefaultImports": true,
+        "allowSyntheticDefaultImports": false,
         "lib": [
             "es2015",
             "dom",


### PR DESCRIPTION
Well, we had a few problems running the library with different boilerplates (angular-universal, angular-starter and so on...).

I decided to fork it and fix so we could start our application right away.

If anyone needs just check my repo or make changes here and will be able to run a SSR angular server just fine with agm.

I also want feedback about it because I'm pretty sure it's not fixed the "best" way or at least not the way maintainers probably wants to. 