### PR TITLE
fix(Polyline): add an input() property "icons" to AgmPolyline

### DIFF
--- a/packages/core/directives/polyline.ts
+++ b/packages/core/directives/polyline.ts
@@ -1,7 +1,7 @@
 import { AfterContentInit, ContentChildren, Directive, EventEmitter, OnChanges, OnDestroy, QueryList, SimpleChanges, Input, Output } from '@angular/core';
 import { Subscription } from 'rxjs';
 
-import { PolyMouseEvent } from '../services/google-maps-types';
+import { PolyMouseEvent, IconSequence } from '../services/google-maps-types';
 import { PolylineManager } from '../services/managers/polyline-manager';
 import { AgmPolylinePoint } from './polyline-point';
 
@@ -77,6 +77,11 @@ export class AgmPolyline implements OnDestroy, OnChanges, AfterContentInit {
    * The stroke width in pixels.
    */
   @Input() strokeWeight: number;
+
+  /**
+   * The icons to be rendered along the polyline.
+   */
+  @Input() icons: Array<IconSequence>;
 
   /**
    * Whether this polyline is visible on the map. Defaults to true.

--- a/packages/core/directives/polyline.ts
+++ b/packages/core/directives/polyline.ts
@@ -155,7 +155,7 @@ export class AgmPolyline implements OnDestroy, OnChanges, AfterContentInit {
 
   private static _polylineOptionsAttributes: Array<string> = [
     'draggable', 'editable', 'visible', 'geodesic', 'strokeColor', 'strokeOpacity', 'strokeWeight',
-    'zIndex'
+    'zIndex', 'icons'
   ];
 
   private _id: string;

--- a/packages/core/services/managers/polyline-manager.spec.ts
+++ b/packages/core/services/managers/polyline-manager.spec.ts
@@ -39,6 +39,7 @@ describe('PolylineManager', () => {
                strokeWeight: undefined,
                visible: true,
                zIndex: undefined,
+               icons: undefined,
                path: []
              });
            }));

--- a/packages/core/services/managers/polyline-manager.ts
+++ b/packages/core/services/managers/polyline-manager.ts
@@ -32,6 +32,7 @@ export class PolylineManager {
       strokeWeight: line.strokeWeight,
       visible: line.visible,
       zIndex: line.zIndex,
+      icons: line.icons,
       path: path
     });
     this._polylines.set(line, polylinePromise);


### PR DESCRIPTION
the icons to be rendered along the polyline
we can draw dashed lines with it
(I need to draw dashed line in my application but seems icons property is missing in AgmPloyline Class. ref:https://developers.google.com/maps/documentation/javascript/examples/overlay-symbol-dashed )