### PR TITLE
fix(PolylinePoint): prevent accessing undefined variable on change

### DIFF
--- a/packages/core/directives/polyline-point.spec.ts
+++ b/packages/core/directives/polyline-point.spec.ts
@@ -1,0 +1,49 @@
+import {SimpleChange, SimpleChanges} from '@angular/core';
+import {AgmPolylinePoint} from './polyline-point';
+
+describe('AgmPolylinePoint', () => {
+  describe('ngOnChanges', () => {
+    it('should emit positionChanged on latitude change', () => {
+      const polylinePoint = new AgmPolylinePoint();
+      polylinePoint.latitude = 50;
+      polylinePoint.longitude = -50;
+      polylinePoint.positionChanged.emit = jest.fn();
+
+      const positionChanges:
+          SimpleChanges = {'latitude': new SimpleChange('previousLat', 'newLat', false)};
+
+      polylinePoint.ngOnChanges(positionChanges);
+
+      expect(polylinePoint.positionChanged.emit).toHaveBeenCalledWith({lat: 'newLat', lng: -50});
+    });
+    it('should emit positionChanged on longitude change', () => {
+      const polylinePoint = new AgmPolylinePoint();
+      polylinePoint.latitude = 50;
+      polylinePoint.longitude = -50;
+      polylinePoint.positionChanged.emit = jest.fn();
+
+      const positionChanges:
+          SimpleChanges = {'longitude': new SimpleChange('previousLng', 'newLng', false)};
+
+      polylinePoint.ngOnChanges(positionChanges);
+
+      expect(polylinePoint.positionChanged.emit).toHaveBeenCalledWith({lat: 50, lng: 'newLng'});
+    });
+    it('should emit positionChanged on latitude and longitude change', () => {
+      const polylinePoint = new AgmPolylinePoint();
+      polylinePoint.latitude = 50;
+      polylinePoint.longitude = -50;
+      polylinePoint.positionChanged.emit = jest.fn();
+
+      const positionChanges: SimpleChanges = {
+        'latitude': new SimpleChange('previousLat', 'newLat', false),
+        'longitude': new SimpleChange('previousLng', 'newLng', false)
+      };
+
+      polylinePoint.ngOnChanges(positionChanges);
+
+      expect(polylinePoint.positionChanged.emit)
+          .toHaveBeenCalledWith({lat: 'newLat', lng: 'newLng'});
+    });
+  });
+});

--- a/packages/core/directives/polyline-point.ts
+++ b/packages/core/directives/polyline-point.ts
@@ -27,8 +27,8 @@ export class AgmPolylinePoint implements OnChanges {
   ngOnChanges(changes: SimpleChanges): any {
     if (changes['latitude'] || changes['longitude']) {
       const position: LatLngLiteral = <LatLngLiteral>{
-        lat: changes['latitude'].currentValue,
-        lng: changes['longitude'].currentValue
+        lat: changes['latitude'] ? changes['latitude'].currentValue : this.latitude,
+        lng: changes['longitude'] ? changes['longitude'].currentValue : this.longitude
       };
       this.positionChanged.emit(position);
     }


### PR DESCRIPTION
Bug already discussed in the following issue:
https://github.com/SebastianM/angular-google-maps/issues/1268

When updating only the latitude or longitude of a PolylinePoint, an error is thrown by ngOnChanges.