### PR TITLE
feat: allow disabling a "point of interest" default info window

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@compodoc/compodoc": "^1.0.0-beta.9",
     "@ngtools/webpack": "^7.2.1",
     "@types/jest": "^23.0.0",
+    "@types/googlemaps": "^3.30.16",
     "angular2-template-loader": "^0.6.2",
     "awesome-typescript-loader": "^5.2.1",
     "clang-format": "1.2.3",

--- a/packages/core/directives/map.ts
+++ b/packages/core/directives/map.ts
@@ -1,21 +1,24 @@
-import { Component, ElementRef, EventEmitter, OnChanges, OnDestroy, OnInit, SimpleChanges, Input, Output } from '@angular/core';
-import {Subscription} from 'rxjs';
+/// <reference types="@types/googlemaps" />
 
-import {MouseEvent} from '../map-types';
-import {GoogleMapsAPIWrapper} from '../services/google-maps-api-wrapper';
+import { Component, ElementRef, EventEmitter, OnChanges, OnDestroy, OnInit, SimpleChanges, Input, Output } from '@angular/core';
+import { Subscription } from 'rxjs';
+
+import { MouseEvent } from '../map-types';
+import { GoogleMapsAPIWrapper } from '../services/google-maps-api-wrapper';
 import {
   FullscreenControlOptions, LatLng, LatLngLiteral, MapTypeControlOptions, MapTypeId, PanControlOptions,
-  RotateControlOptions, ScaleControlOptions, StreetViewControlOptions, ZoomControlOptions} from '../services/google-maps-types';
-import {LatLngBounds, LatLngBoundsLiteral, MapTypeStyle} from '../services/google-maps-types';
-import {CircleManager} from '../services/managers/circle-manager';
-import {RectangleManager} from '../services/managers/rectangle-manager';
-import {InfoWindowManager} from '../services/managers/info-window-manager';
-import {MarkerManager} from '../services/managers/marker-manager';
-import {PolygonManager} from '../services/managers/polygon-manager';
-import {PolylineManager} from '../services/managers/polyline-manager';
-import {KmlLayerManager} from './../services/managers/kml-layer-manager';
-import {DataLayerManager} from './../services/managers/data-layer-manager';
-import {FitBoundsService} from '../services/fit-bounds';
+  RotateControlOptions, ScaleControlOptions, StreetViewControlOptions, ZoomControlOptions
+} from '../services/google-maps-types';
+import { LatLngBounds, LatLngBoundsLiteral, MapTypeStyle } from '../services/google-maps-types';
+import { CircleManager } from '../services/managers/circle-manager';
+import { RectangleManager } from '../services/managers/rectangle-manager';
+import { InfoWindowManager } from '../services/managers/info-window-manager';
+import { MarkerManager } from '../services/managers/marker-manager';
+import { PolygonManager } from '../services/managers/polygon-manager';
+import { PolylineManager } from '../services/managers/polyline-manager';
+import { KmlLayerManager } from './../services/managers/kml-layer-manager';
+import { DataLayerManager } from './../services/managers/data-layer-manager';
+import { FitBoundsService } from '../services/fit-bounds';
 
 declare var google: any;
 
@@ -43,31 +46,33 @@ declare var google: any;
  * ```
  */
 @Component({
-  selector: 'agm-map',
+  selector:  'agm-map',
   providers: [
     GoogleMapsAPIWrapper, MarkerManager, InfoWindowManager, CircleManager, RectangleManager,
     PolylineManager, PolygonManager, KmlLayerManager, DataLayerManager, DataLayerManager,
     FitBoundsService
   ],
-  host: {
+  host:      {
     // todo: deprecated - we will remove it with the next version
     '[class.sebm-google-map-container]': 'true'
   },
-  styles: [`
-    .agm-map-container-inner {
-      width: inherit;
-      height: inherit;
-    }
-    .agm-map-content {
-      display:none;
-    }
-  `],
-  template: `
-    <div class='agm-map-container-inner sebm-google-map-container-inner'></div>
-    <div class='agm-map-content'>
-      <ng-content></ng-content>
-    </div>
-  `
+  styles:    [
+      `
+      .agm-map-container-inner {
+        width: inherit;
+        height: inherit;
+      }
+
+      .agm-map-content {
+        display: none;
+      }
+    `],
+  template:  `
+               <div class='agm-map-container-inner sebm-google-map-container-inner'></div>
+               <div class='agm-map-content'>
+                 <ng-content></ng-content>
+               </div>
+             `
 })
 export class AgmMap implements OnChanges, OnInit, OnDestroy {
   /**
@@ -100,7 +105,7 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
   /**
    * Enables/disables if map is draggable.
    */
-  // tslint:disable-next-line:no-input-rename
+    // tslint:disable-next-line:no-input-rename
   @Input('mapDraggable') draggable: boolean = true;
 
   /**
@@ -186,7 +191,7 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
    * Sets the viewport to contain the given bounds.
    * If this option to `true`, the bounds get automatically computed from all elements that use the {@link AgmFitBounds} directive.
    */
-  @Input() fitBounds: LatLngBoundsLiteral|LatLngBounds|boolean = false;
+  @Input() fitBounds: LatLngBoundsLiteral | LatLngBounds | boolean = false;
 
   /**
    * The initial enabled/disabled state of the Scale control. This is disabled by default.
@@ -211,7 +216,7 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
   /**
    * The initial enabled/disabled state of the Pan control.
    */
-  @Input() panControl: boolean  = false;
+  @Input() panControl: boolean = false;
 
   /**
    * Options for the Pan control.
@@ -231,7 +236,7 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
   /**
    * The initial enabled/disabled state of the Fullscreen control.
    */
-  @Input() fullscreenControl: boolean  = false;
+  @Input() fullscreenControl: boolean = false;
 
   /**
    * Options for the Fullscreen control.
@@ -241,13 +246,21 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
   /**
    * The map mapTypeId. Defaults to 'roadmap'.
    */
-  @Input() mapTypeId: 'roadmap'|'hybrid'|'satellite'|'terrain'|string = 'roadmap';
+  @Input() mapTypeId: 'roadmap' | 'hybrid' | 'satellite' | 'terrain' | string = 'roadmap';
 
   /**
    * When false, map icons are not clickable. A map icon represents a point of interest,
    * also known as a POI. By default map icons are clickable.
    */
   @Input() clickableIcons: boolean = true;
+
+  /**
+   * A map icon represents a point of interest, also known as a POI.
+   * When map icons are clickable by default, an info window is displayed.
+   * When this property is set to npm run buildfalse, the info window will not be shown but the click event
+   * will still fire
+   */
+  @Input() isToShowDefaultInfoWindowForIcons: boolean = true;
 
   /**
    * This setting controls how gestures on the map are handled.
@@ -257,7 +270,7 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
    * - 'none'        (The map cannot be panned or zoomed by user gestures.)
    * - 'auto'        [default] (Gesture handling is either cooperative or greedy, depending on whether the page is scrollable or not.
    */
-  @Input() gestureHandling: 'cooperative'|'greedy'|'none'|'auto' = 'auto';
+  @Input() gestureHandling: 'cooperative' | 'greedy' | 'none' | 'auto' = 'auto';
 
   /**
    * Map option attributes that can change over time
@@ -268,7 +281,7 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
     'streetViewControlOptions', 'zoom', 'mapTypeControl', 'mapTypeControlOptions', 'minZoom',
     'maxZoom', 'panControl', 'panControlOptions', 'rotateControl', 'rotateControlOptions',
     'fullscreenControl', 'fullscreenControlOptions', 'scaleControl', 'scaleControlOptions',
-    'mapTypeId', 'clickableIcons', 'gestureHandling'
+    'mapTypeId', 'clickableIcons', 'isToShowDefaultInfoWindowForIcons', 'gestureHandling'
   ];
 
   private _observableSubscriptions: Subscription[] = [];
@@ -323,7 +336,8 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
    */
   @Output() mapReady: EventEmitter<any> = new EventEmitter<any>();
 
-  constructor(private _elem: ElementRef, private _mapsWrapper: GoogleMapsAPIWrapper, protected _fitBoundsService: FitBoundsService) {}
+  constructor(private _elem: ElementRef, private _mapsWrapper: GoogleMapsAPIWrapper, protected _fitBoundsService: FitBoundsService) {
+  }
 
   /** @internal */
   ngOnInit() {
@@ -334,36 +348,37 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
 
   private _initMapInstance(el: HTMLElement) {
     this._mapsWrapper.createMap(el, {
-      center: {lat: this.latitude || 0, lng: this.longitude || 0},
-      zoom: this.zoom,
-      minZoom: this.minZoom,
-      maxZoom: this.maxZoom,
-      disableDefaultUI: this.disableDefaultUI,
-      disableDoubleClickZoom: this.disableDoubleClickZoom,
-      scrollwheel: this.scrollwheel,
-      backgroundColor: this.backgroundColor,
-      draggable: this.draggable,
-      draggableCursor: this.draggableCursor,
-      draggingCursor: this.draggingCursor,
-      keyboardShortcuts: this.keyboardShortcuts,
-      styles: this.styles,
-      zoomControl: this.zoomControl,
-      zoomControlOptions: this.zoomControlOptions,
-      streetViewControl: this.streetViewControl,
-      streetViewControlOptions: this.streetViewControlOptions,
-      scaleControl: this.scaleControl,
-      scaleControlOptions: this.scaleControlOptions,
-      mapTypeControl: this.mapTypeControl,
-      mapTypeControlOptions: this.mapTypeControlOptions,
-      panControl: this.panControl,
-      panControlOptions: this.panControlOptions,
-      rotateControl: this.rotateControl,
-      rotateControlOptions: this.rotateControlOptions,
-      fullscreenControl: this.fullscreenControl,
-      fullscreenControlOptions: this.fullscreenControlOptions,
-      mapTypeId: this.mapTypeId,
-      clickableIcons: this.clickableIcons,
-      gestureHandling: this.gestureHandling
+      center:                            { lat: this.latitude || 0, lng: this.longitude || 0 },
+      zoom:                              this.zoom,
+      minZoom:                           this.minZoom,
+      maxZoom:                           this.maxZoom,
+      disableDefaultUI:                  this.disableDefaultUI,
+      disableDoubleClickZoom:            this.disableDoubleClickZoom,
+      scrollwheel:                       this.scrollwheel,
+      backgroundColor:                   this.backgroundColor,
+      draggable:                         this.draggable,
+      draggableCursor:                   this.draggableCursor,
+      draggingCursor:                    this.draggingCursor,
+      keyboardShortcuts:                 this.keyboardShortcuts,
+      styles:                            this.styles,
+      zoomControl:                       this.zoomControl,
+      zoomControlOptions:                this.zoomControlOptions,
+      streetViewControl:                 this.streetViewControl,
+      streetViewControlOptions:          this.streetViewControlOptions,
+      scaleControl:                      this.scaleControl,
+      scaleControlOptions:               this.scaleControlOptions,
+      mapTypeControl:                    this.mapTypeControl,
+      mapTypeControlOptions:             this.mapTypeControlOptions,
+      panControl:                        this.panControl,
+      panControlOptions:                 this.panControlOptions,
+      rotateControl:                     this.rotateControl,
+      rotateControlOptions:              this.rotateControlOptions,
+      fullscreenControl:                 this.fullscreenControl,
+      fullscreenControlOptions:          this.fullscreenControlOptions,
+      mapTypeId:                         this.mapTypeId,
+      clickableIcons:                    this.clickableIcons,
+      isToShowDefaultInfoWindowForIcons: this.isToShowDefaultInfoWindowForIcons,
+      gestureHandling:                   this.gestureHandling
     })
       .then(() => this._mapsWrapper.getNativeMap())
       .then(map => this.mapReady.emit(map));
@@ -396,10 +411,12 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
   }
 
   private _updateMapOptionsChanges(changes: SimpleChanges) {
-    let options: {[propName: string]: any} = {};
+    let options: { [propName: string]: any } = {};
     let optionKeys =
-        Object.keys(changes).filter(k => AgmMap._mapOptionsAttributes.indexOf(k) !== -1);
-    optionKeys.forEach((k) => { options[k] = changes[k].currentValue; });
+      Object.keys(changes).filter(k => AgmMap._mapOptionsAttributes.indexOf(k) !== -1);
+    optionKeys.forEach((k) => {
+      options[k] = changes[k].currentValue;
+    });
     this._mapsWrapper.setMapOptions(options);
   }
 
@@ -426,7 +443,7 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
 
   private _updatePosition(changes: SimpleChanges) {
     if (changes['latitude'] == null && changes['longitude'] == null &&
-        !changes['fitBounds']) {
+      !changes['fitBounds']) {
       // no position update needed
       return;
     }
@@ -446,7 +463,7 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
   private _setCenter() {
     let newCenter = {
       lat: this.latitude,
-      lng: this.longitude,
+      lng: this.longitude
     };
     if (this.usePanning) {
       this._mapsWrapper.panTo(newCenter);
@@ -459,14 +476,14 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
     switch (this.fitBounds) {
       case true:
         this._subscribeToFitBoundsUpdates();
-      break;
+        break;
       case false:
         if (this._fitBoundsSubscription) {
           this._fitBoundsSubscription.unsubscribe();
         }
-       break;
-       default:
-       this._updateBounds(this.fitBounds);
+        break;
+      default:
+        this._updateBounds(this.fitBounds);
     }
   }
 
@@ -474,7 +491,7 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
     this._fitBoundsSubscription = this._fitBoundsService.getBounds$().subscribe(b => this._updateBounds(b));
   }
 
-  protected _updateBounds(bounds: LatLngBounds|LatLngBoundsLiteral) {
+  protected _updateBounds(bounds: LatLngBounds | LatLngBoundsLiteral) {
     if (this._isLatLngBoundsLiteral(bounds) && google && google.maps) {
       const newBounds = new google.maps.LatLngBounds();
       newBounds.union(bounds);
@@ -487,7 +504,7 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
     this._mapsWrapper.fitBounds(bounds);
   }
 
-  private _isLatLngBoundsLiteral(bounds: LatLngBounds|LatLngBoundsLiteral): bounds is LatLngBoundsLiteral {
+  private _isLatLngBoundsLiteral(bounds: LatLngBounds | LatLngBoundsLiteral): bounds is LatLngBoundsLiteral {
     return bounds != null && (<any>bounds).extend === undefined;
   }
 
@@ -496,7 +513,7 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
       this._mapsWrapper.getCenter().then((center: LatLng) => {
         this.latitude = center.lat();
         this.longitude = center.lng();
-        this.centerChange.emit(<LatLngLiteral>{lat: this.latitude, lng: this.longitude});
+        this.centerChange.emit(<LatLngLiteral>{ lat: this.latitude, lng: this.longitude });
       });
     });
     this._observableSubscriptions.push(s);
@@ -505,7 +522,9 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
   private _handleBoundsChange() {
     const s = this._mapsWrapper.subscribeToMapEvent<void>('bounds_changed').subscribe(() => {
       this._mapsWrapper.getBounds().then(
-          (bounds: LatLngBounds) => { this.boundsChange.emit(bounds); });
+        (bounds: LatLngBounds) => {
+          this.boundsChange.emit(bounds);
+        });
     });
     this._observableSubscriptions.push(s);
   }
@@ -513,7 +532,9 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
   private _handleMapTypeIdChange() {
     const s = this._mapsWrapper.subscribeToMapEvent<void>('maptypeid_changed').subscribe(() => {
       this._mapsWrapper.getMapTypeId().then(
-          (mapTypeId: MapTypeId) => { this.mapTypeIdChange.emit(mapTypeId); });
+        (mapTypeId: MapTypeId) => {
+          this.mapTypeIdChange.emit(mapTypeId);
+        });
     });
     this._observableSubscriptions.push(s);
   }
@@ -530,7 +551,9 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
 
   private _handleIdleEvent() {
     const s = this._mapsWrapper.subscribeToMapEvent<void>('idle').subscribe(
-        () => { this.idle.emit(void 0); });
+      () => {
+        this.idle.emit(void 0);
+      });
     this._observableSubscriptions.push(s);
   }
 
@@ -538,20 +561,32 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
     interface Emitter {
       emit(value: any): void;
     }
-    type Event = {name: string, emitter: Emitter};
+
+    type Event = { name: string, emitter: Emitter };
 
     const events: Event[] = [
-      {name: 'click', emitter: this.mapClick},
-      {name: 'rightclick', emitter: this.mapRightClick},
-      {name: 'dblclick', emitter: this.mapDblClick},
+      { name: 'click', emitter: this.mapClick },
+      { name: 'rightclick', emitter: this.mapRightClick },
+      { name: 'dblclick', emitter: this.mapDblClick }
     ];
 
     events.forEach((e: Event) => {
-      const s = this._mapsWrapper.subscribeToMapEvent<{latLng: LatLng}>(e.name).subscribe(
-          (event: {latLng: LatLng}) => {
-            const value = <MouseEvent>{coords: {lat: event.latLng.lat(), lng: event.latLng.lng()}};
-            e.emitter.emit(value);
-          });
+      const s = this._mapsWrapper.subscribeToMapEvent<google.maps.MouseEvent>(e.name).subscribe(
+        (event: google.maps.MouseEvent) => {
+          let value: MouseEvent = {
+            coords: {
+              lat: event.latLng.lat(),
+              lng: event.latLng.lng()
+            }
+          };
+          // we cant use instanceOf since the IconMouseEvent is an interface
+          if ((<any>event).placeId !== undefined && (<any>event).placeId !== null) {
+            if (!this.isToShowDefaultInfoWindowForIcons) {
+              event.stop();
+            }
+          }
+          e.emitter.emit(value);
+        });
       this._observableSubscriptions.push(s);
     });
   }

--- a/packages/core/services/google-maps-types.ts
+++ b/packages/core/services/google-maps-types.ts
@@ -185,6 +185,7 @@ export interface MapOptions {
   fullscreenControlOptions?: FullscreenControlOptions;
   mapTypeId?: string|MapTypeId;
   clickableIcons?: boolean;
+  isToShowDefaultInfoWindowForIcons?: boolean;
   gestureHandling?: 'cooperative'|'greedy'|'none'|'auto';
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -191,6 +191,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.38.tgz#c1be40aa933723c608820a99a373a16d215a1ca2"
   integrity sha512-F/v7t1LwS4vnXuPooJQGBRKRGIoxWUTmA4VHfqjOccFsNDThD5bfUNpITive6s352O7o384wcpEaDV8rHCehDA==
 
+"@types/googlemaps@^3.30.16":
+  version "3.30.16"
+  resolved "https://registry.yarnpkg.com/@types/googlemaps/-/googlemaps-3.30.16.tgz#3264d5ef7c3a92fab2a9f00e09e3247866ff3532"
+  integrity sha512-6OZ64ahLzYfzuSr71y4jAHZXiwxjvvEM2bfF2tzjIc9KUZVbO30SkYa8WewTsR8aM5BFz/uBiNlZ14eRLXYS0g==
+
 "@types/jest@^23.0.0":
   version "23.3.12"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.12.tgz#7e0ced251fa94c3bc2d1023d4b84b2992fa06376"


### PR DESCRIPTION
allow disabling a "point of interest" default info window.
use it by passing a boolean value to the new property isToShowDefaultInfoWindowForIcons when initializing the map. default value is true.

closes issue #1539.