### PR TITLE
Extend useful map wrapper functions

### DIFF
--- a/packages/core/directives/map.ts
+++ b/packages/core/directives/map.ts
@@ -424,6 +424,18 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
     });
   }
 
+  getBounds(): Promise<LatLngBounds> {
+    return this._mapsWrapper.getBounds();
+  }
+
+  getCenter(): Promise<LatLng> {
+    return this._mapsWrapper.getCenter();
+  }
+
+  getZoom(): Promise<number> {
+    return this._mapsWrapper.getZoom();
+  }
+
   private _updatePosition(changes: SimpleChanges) {
     if (changes['latitude'] == null && changes['longitude'] == null &&
         !changes['fitBounds']) {


### PR DESCRIPTION
Adding these functions provides the user with the ability to get the bounds, center, or zoom on initialization/without having to rely on an event being triggered. Additionally, if the user is doing some expensive computation in event handlers, they can chose to do do them in the idle event handler as opposed to the any of the event handlers that update through the entire map transformation.