### PR TITLE
fix: extra map move after set center

### DIFF
--- a/packages/core/directives/map.ts
+++ b/packages/core/directives/map.ts
@@ -440,7 +440,12 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
     if (typeof this.latitude !== 'number' || typeof this.longitude !== 'number') {
       return;
     }
-    this._setCenter();
+    this._mapsWrapper.getCenter().then((center: LatLng) => {
+      if (center.lat() === this.latitude && center.lng() === this.longitude) {
+        return;
+      }
+      this._setCenter();
+    });
   }
 
   private _setCenter() {


### PR DESCRIPTION
STR
1. Set [longitude] and [latitude]
2. Move the map.
3. Then update [longitude] and [latitude]. However even if `map.getCenter() === [longitude] and [latitude]` the native map recalculates the center. After the recalculations the new center may be different. If the center a bit different it cause `mapMove()`  again.

A typical case.

1. Get a center from a store or from anywhere in your app. 
2. Set it by `@Input()` in agm-map.
2. Move the map. It updates native map's center. But doesn't update the center from `@Input()`
3. Then you decided to update the store with a current center . It cause @Input() updates because the previous value is not the same with the new one. 
4. So here is the problem `ngOnChanges` calls `_updatePosition()` which in turn causes native map's center update. And as I've written before after the recalculations the center may be a bit different.
