### PR TITLE
fix(fit-bounds) enable local builds

### DIFF
--- a/packages/core/core.module.ts
+++ b/packages/core/core.module.ts
@@ -13,7 +13,7 @@ import {LazyMapsAPILoader} from './services/maps-api-loader/lazy-maps-api-loader
 import {LAZY_MAPS_API_CONFIG, LazyMapsAPILoaderConfigLiteral} from './services/maps-api-loader/lazy-maps-api-loader';
 import {MapsAPILoader} from './services/maps-api-loader/maps-api-loader';
 import {BROWSER_GLOBALS_PROVIDERS} from './utils/browser-globals';
-import {AgmFitBounds} from '@agm/core/directives/fit-bounds';
+import {AgmFitBounds} from './directives/fit-bounds';
 
 /**
  * @internal


### PR DESCRIPTION
the absolute import caused issues with some local building. Now, it's uniform with the other imports and the problem is gone.

Fix #937