### PR TITLE
Update map.ts - Adding controlSize property

### DIFF
--- a/packages/core/directives/map.ts
+++ b/packages/core/directives/map.ts
@@ -97,8 +97,8 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
    * are enforced.
    */
   @Input() maxZoom: number;
-  
-   /**
+
+  /**
    * The control size for the default map controls. Only governs the controls made by the Maps API itself
    */
   @Input() controlSize: number;

--- a/packages/core/directives/map.ts
+++ b/packages/core/directives/map.ts
@@ -97,6 +97,11 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
    * are enforced.
    */
   @Input() maxZoom: number;
+  
+   /**
+   * The control size for the default map controls. Only governs the controls made by the Maps API itself
+   */
+  @Input() controlSize: number;
 
   /**
    * Enables/disables if map is draggable.
@@ -288,7 +293,7 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
     'disableDoubleClickZoom', 'scrollwheel', 'draggable', 'draggableCursor', 'draggingCursor',
     'keyboardShortcuts', 'zoomControl', 'zoomControlOptions', 'styles', 'streetViewControl',
     'streetViewControlOptions', 'zoom', 'mapTypeControl', 'mapTypeControlOptions', 'minZoom',
-    'maxZoom', 'panControl', 'panControlOptions', 'rotateControl', 'rotateControlOptions',
+    'maxZoom', 'controlSize', 'panControl', 'panControlOptions', 'rotateControl', 'rotateControlOptions',
     'fullscreenControl', 'fullscreenControlOptions', 'scaleControl', 'scaleControlOptions',
     'mapTypeId', 'clickableIcons', 'gestureHandling', 'tilt', 'restriction'
   ];
@@ -360,6 +365,7 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
       zoom: this.zoom,
       minZoom: this.minZoom,
       maxZoom: this.maxZoom,
+      controlSize: this.controlSize,
       disableDefaultUI: this.disableDefaultUI,
       disableDoubleClickZoom: this.disableDoubleClickZoom,
       scrollwheel: this.scrollwheel,

--- a/packages/core/directives/map.ts
+++ b/packages/core/directives/map.ts
@@ -293,7 +293,7 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
     'disableDoubleClickZoom', 'scrollwheel', 'draggable', 'draggableCursor', 'draggingCursor',
     'keyboardShortcuts', 'zoomControl', 'zoomControlOptions', 'styles', 'streetViewControl',
     'streetViewControlOptions', 'zoom', 'mapTypeControl', 'mapTypeControlOptions', 'minZoom',
-    'maxZoom', 'controlSize', 'panControl', 'panControlOptions', 'rotateControl', 'rotateControlOptions',
+    'maxZoom', 'panControl', 'panControlOptions', 'rotateControl', 'rotateControlOptions',
     'fullscreenControl', 'fullscreenControlOptions', 'scaleControl', 'scaleControlOptions',
     'mapTypeId', 'clickableIcons', 'gestureHandling', 'tilt', 'restriction'
   ];

--- a/packages/core/services/google-maps-types.ts
+++ b/packages/core/services/google-maps-types.ts
@@ -161,7 +161,7 @@ export interface MapOptions {
   zoom?: number;
   minZoom?: number;
   maxZoom?: number;
-  controlSize: number;
+  controlSize?: number;
   disableDoubleClickZoom?: boolean;
   disableDefaultUI?: boolean;
   scrollwheel?: boolean;

--- a/packages/core/services/google-maps-types.ts
+++ b/packages/core/services/google-maps-types.ts
@@ -161,6 +161,7 @@ export interface MapOptions {
   zoom?: number;
   minZoom?: number;
   maxZoom?: number;
+  controlSize: number;
   disableDoubleClickZoom?: boolean;
   disableDefaultUI?: boolean;
   scrollwheel?: boolean;


### PR DESCRIPTION
Adding the `controlSize` properties - addressing issue: https://github.com/SebastianM/angular-google-maps/issues/1646