### PR TITLE
fix: google is not defined when using fitBounds

### DIFF
--- a/packages/core/directives/map.ts
+++ b/packages/core/directives/map.ts
@@ -517,7 +517,7 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
   }
 
   protected _updateBounds(bounds: LatLngBounds|LatLngBoundsLiteral) {
-    if (this._isLatLngBoundsLiteral(bounds) && google && google.maps) {
+    if (this._isLatLngBoundsLiteral(bounds) && typeof google !== 'undefined' && google && google.maps && google.maps.LatLngBounds) {
       const newBounds = new google.maps.LatLngBounds();
       newBounds.union(bounds);
       bounds = newBounds;


### PR DESCRIPTION
fixes #1586
Add two more checks before using  google.maps.LatLngBounds() in _updateBounds function