### PR TITLE
Add "MarkerIcon" type for AgmMarker.iconUrl field

### DIFF
--- a/packages/core/directives/marker.ts
+++ b/packages/core/directives/marker.ts
@@ -6,6 +6,7 @@ import { FitBoundsAccessor, FitBoundsDetails } from '../services/fit-bounds';
 import * as mapTypes from '../services/google-maps-types';
 import { MarkerManager } from '../services/managers/marker-manager';
 import { AgmInfoWindow } from './info-window';
+import { GoogleSymbol, MarkerIcon } from "@agm/core/services/google-maps-types";
 
 let markerId = 0;
 
@@ -72,8 +73,10 @@ export class AgmMarker implements OnDestroy, OnChanges, AfterContentInit, FitBou
 
   /**
    * Icon (the URL of the image) for the foreground.
+   * Can also be a MarkerIcon (google.maps.Icon in Google Maps Javascript api)
+   * @see <a href="https://developers.google.com/maps/documentation/javascript/reference/marker#Icon">google.maps.Icon</a>
    */
-  @Input() iconUrl: string;
+  @Input() iconUrl: string | MarkerIcon;
 
   /**
    * If true, the marker is visible

--- a/packages/core/services/google-maps-types.ts
+++ b/packages/core/services/google-maps-types.ts
@@ -62,6 +62,15 @@ export interface MarkerLabel {
   text: string;
 }
 
+export interface MarkerIcon {
+  url: string;
+  anchor?: { x, y };
+  labelOrigin?: { x, y };
+  origin?: { x, y };
+  scaledSize?: { width, height };
+  size?: { width, height };
+}
+
 export interface Circle extends MVCObject {
   getBounds(): LatLngBounds;
   getCenter(): LatLng;


### PR DESCRIPTION
As AgmMarker.iconUrl field support google.maps.Icon type, we should add it to typescript definition.
Icon type is very usefull to create custom Icon and change it position on screen