### PR TITLE
feat(*): Support for Transit Layer

### DIFF
--- a/packages/core/core.module.ts
+++ b/packages/core/core.module.ts
@@ -15,6 +15,7 @@ import {MapsAPILoader} from './services/maps-api-loader/maps-api-loader';
 import {BROWSER_GLOBALS_PROVIDERS} from './utils/browser-globals';
 import {AgmFitBounds} from './directives/fit-bounds';
 import { AgmPolylineIcon } from './directives/polyline-icon';
+import { AgmTransitLayer } from './directives/transit-layer';
 
 /**
  * @internal
@@ -23,7 +24,7 @@ export function coreDirectives() {
   return [
     AgmMap, AgmMarker, AgmInfoWindow, AgmCircle, AgmRectangle,
     AgmPolygon, AgmPolyline, AgmPolylinePoint, AgmKmlLayer,
-    AgmDataLayer, AgmFitBounds, AgmPolylineIcon
+    AgmDataLayer, AgmFitBounds, AgmPolylineIcon, AgmTransitLayer
   ];
 }
 

--- a/packages/core/directives.ts
+++ b/packages/core/directives.ts
@@ -4,6 +4,7 @@ export {AgmRectangle} from './directives/rectangle';
 export {AgmInfoWindow} from './directives/info-window';
 export {AgmKmlLayer} from './directives/kml-layer';
 export {AgmDataLayer} from './directives/data-layer';
+import { AgmTransitLayer } from './directives/transit-layer';
 export {AgmMarker} from './directives/marker';
 export {AgmPolygon} from './directives/polygon';
 export {AgmPolyline} from './directives/polyline';

--- a/packages/core/directives.ts
+++ b/packages/core/directives.ts
@@ -4,7 +4,7 @@ export {AgmRectangle} from './directives/rectangle';
 export {AgmInfoWindow} from './directives/info-window';
 export {AgmKmlLayer} from './directives/kml-layer';
 export {AgmDataLayer} from './directives/data-layer';
-import { AgmTransitLayer } from './directives/transit-layer';
+export {AgmTransitLayer} from './directives/transit-layer';
 export {AgmMarker} from './directives/marker';
 export {AgmPolygon} from './directives/polygon';
 export {AgmPolyline} from './directives/polyline';

--- a/packages/core/directives/fit-bounds.ts
+++ b/packages/core/directives/fit-bounds.ts
@@ -2,7 +2,7 @@ import { Directive, OnInit, Self, OnDestroy, Input, OnChanges, SimpleChanges } f
 import { FitBoundsService, FitBoundsAccessor, FitBoundsDetails } from '../services/fit-bounds';
 import { Subscription, Subject } from 'rxjs';
 import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
-import { LatLng, LatLngLiteral } from '@agm/core';
+import { LatLng, LatLngLiteral } from '@agm/core'; // Does this need to change to '../services/google-maps-types'?
 
 /**
  * Adds the given directive to the auto fit bounds feature when the value is true.

--- a/packages/core/directives/fit-bounds.ts
+++ b/packages/core/directives/fit-bounds.ts
@@ -2,7 +2,7 @@ import { Directive, OnInit, Self, OnDestroy, Input, OnChanges, SimpleChanges } f
 import { FitBoundsService, FitBoundsAccessor, FitBoundsDetails } from '../services/fit-bounds';
 import { Subscription, Subject } from 'rxjs';
 import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
-import { LatLng, LatLngLiteral } from '@agm/core'; // Does this need to change to '../services/google-maps-types'?
+import { LatLng, LatLngLiteral } from '@agm/core';
 
 /**
  * Adds the given directive to the auto fit bounds feature when the value is true.

--- a/packages/core/directives/map.ts
+++ b/packages/core/directives/map.ts
@@ -15,6 +15,7 @@ import { PolygonManager } from '../services/managers/polygon-manager';
 import { PolylineManager } from '../services/managers/polyline-manager';
 import { KmlLayerManager } from './../services/managers/kml-layer-manager';
 import { DataLayerManager } from './../services/managers/data-layer-manager';
+import { TransitLayerManager } from '../services/managers/transit-layer-manager';
 import { FitBoundsService } from '../services/fit-bounds';
 
 declare var google: any;
@@ -47,7 +48,7 @@ declare var google: any;
   providers: [
     GoogleMapsAPIWrapper, MarkerManager, InfoWindowManager, CircleManager, RectangleManager,
     PolylineManager, PolygonManager, KmlLayerManager, DataLayerManager, DataLayerManager,
-    FitBoundsService
+    TransitLayerManager, FitBoundsService
   ],
   host: {
     // todo: deprecated - we will remove it with the next version

--- a/packages/core/directives/transit-layer.ts
+++ b/packages/core/directives/transit-layer.ts
@@ -1,0 +1,65 @@
+import { Directive, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { TransitLayerManager } from '../services/managers/transit-layer-manager';
+
+let layerId = 0;
+
+@Directive({
+    selector: 'agm-transit-layer'
+})
+
+/*
+* This directive adds a transit layer to a google map instance
+* <agm-transit-layer [inVisible]="true|false"> <agm-transit-layer>
+* */
+
+export class AgmTransitLayer implements OnInit, OnChanges, OnDestroy{
+    private _addedToManager: boolean = false;
+    private _id: string = (layerId++).toString();
+    private static _transitLayerOptions: string[] = [ 'inVisible'];
+
+    /**
+     * Hide/show transit layer
+     */
+    @Input() inVisible: boolean = false;
+
+    constructor( private _manager: TransitLayerManager ) {}
+
+    ngOnInit() {
+        if (this._addedToManager) {
+            return;
+        }
+        this._manager.addTransitLayer(this, {inVisible: this.inVisible});
+        this._addedToManager = true;
+    }
+
+    ngOnChanges(changes: SimpleChanges) {
+        if (!this._addedToManager) {
+            return;
+        }
+        this._updateTransitLayerOptions(changes);
+    }
+
+    private _updateTransitLayerOptions(changes: SimpleChanges) {
+        const options = Object.keys(changes)
+            .filter(k => AgmTransitLayer._transitLayerOptions.indexOf(k) !== -1)
+            .reduce((obj: any, k: string) => {
+                obj[k] = changes[k].currentValue;
+                return obj;
+            }, {});
+        if (Object.keys(options).length > 0) {
+            this._manager.setOptions(this, options);
+        }
+    }
+
+    /** @internal */
+    id(): string { return this._id; }
+
+    /** @internal */
+    toString(): string { return `AgmTransitLayer-${this._id.toString()}`; }
+
+    /** @internal */
+    ngOnDestroy() {
+        this._manager.deleteTransitLayer(this);
+    }
+
+}

--- a/packages/core/directives/transit-layer.ts
+++ b/packages/core/directives/transit-layer.ts
@@ -3,24 +3,23 @@ import { TransitLayerManager } from '../services/managers/transit-layer-manager'
 
 let layerId = 0;
 
+/*
+ * This directive adds a transit layer to a google map instance
+ * <agm-transit-layer [visible]="true|false"> <agm-transit-layer>
+ * */
 @Directive({
     selector: 'agm-transit-layer'
 })
 
-/*
-* This directive adds a transit layer to a google map instance
-* <agm-transit-layer [inVisible]="true|false"> <agm-transit-layer>
-* */
-
 export class AgmTransitLayer implements OnInit, OnChanges, OnDestroy{
     private _addedToManager: boolean = false;
     private _id: string = (layerId++).toString();
-    private static _transitLayerOptions: string[] = [ 'inVisible'];
+    private static _transitLayerOptions: string[] = [ 'visible'];
 
     /**
      * Hide/show transit layer
      */
-    @Input() inVisible: boolean = false;
+    @Input() visible: boolean = true;
 
     constructor( private _manager: TransitLayerManager ) {}
 
@@ -28,7 +27,7 @@ export class AgmTransitLayer implements OnInit, OnChanges, OnDestroy{
         if (this._addedToManager) {
             return;
         }
-        this._manager.addTransitLayer(this, {inVisible: this.inVisible});
+        this._manager.addTransitLayer(this, {visible: this.visible});
         this._addedToManager = true;
     }
 

--- a/packages/core/services.ts
+++ b/packages/core/services.ts
@@ -11,3 +11,4 @@ export {GoogleMapsScriptProtocol, LAZY_MAPS_API_CONFIG, LazyMapsAPILoader, LazyM
 export {MapsAPILoader} from './services/maps-api-loader/maps-api-loader';
 export {NoOpMapsAPILoader} from './services/maps-api-loader/noop-maps-api-loader';
 export {FitBoundsAccessor, FitBoundsDetails} from './services/fit-bounds';
+import {TransitLayerManager} from './services/managers/transit-layer-manager';

--- a/packages/core/services.ts
+++ b/packages/core/services.ts
@@ -11,4 +11,4 @@ export {GoogleMapsScriptProtocol, LAZY_MAPS_API_CONFIG, LazyMapsAPILoader, LazyM
 export {MapsAPILoader} from './services/maps-api-loader/maps-api-loader';
 export {NoOpMapsAPILoader} from './services/maps-api-loader/noop-maps-api-loader';
 export {FitBoundsAccessor, FitBoundsDetails} from './services/fit-bounds';
-import {TransitLayerManager} from './services/managers/transit-layer-manager';
+export {TransitLayerManager} from './services/managers/transit-layer-manager';

--- a/packages/core/services/google-maps-api-wrapper.ts
+++ b/packages/core/services/google-maps-api-wrapper.ts
@@ -5,7 +5,6 @@ import * as mapTypes from './google-maps-types';
 import {Polyline} from './google-maps-types';
 import {PolylineOptions} from './google-maps-types';
 import {MapsAPILoader} from './maps-api-loader/maps-api-loader';
-import {MapTypeStyle} from './google-maps-types';
 
 // todo: add types for this
 declare var google: any;
@@ -113,7 +112,7 @@ export class GoogleMapsAPIWrapper {
   createTransitLayer(options: mapTypes.TransitLayerOptions): Promise<mapTypes.TransitLayer>{
     return this._map.then((map: mapTypes.GoogleMap) => {
       let transitLayer: mapTypes.TransitLayer = new google.maps.TransitLayer();
-      transitLayer.setMap(options.inVisible ? null : map);
+      transitLayer.setMap(options.visible ? map : null);
       return transitLayer;
     });
   }

--- a/packages/core/services/google-maps-api-wrapper.ts
+++ b/packages/core/services/google-maps-api-wrapper.ts
@@ -5,6 +5,7 @@ import * as mapTypes from './google-maps-types';
 import {Polyline} from './google-maps-types';
 import {PolylineOptions} from './google-maps-types';
 import {MapsAPILoader} from './maps-api-loader/maps-api-loader';
+import {MapTypeStyle} from './google-maps-types';
 
 // todo: add types for this
 declare var google: any;
@@ -101,6 +102,19 @@ export class GoogleMapsAPIWrapper {
       let data = new google.maps.Data(options);
       data.setMap(m);
       return data;
+    });
+  }
+
+  /**
+   * Creates a Google Map transit layer instance add it to map
+   * @param {TransitLayerOptions} options - TransitLayerOptions options
+   * @returns {Promise<TransitLayer>} a new transit layer object
+   */
+  createTransitLayer(options: mapTypes.TransitLayerOptions): Promise<mapTypes.TransitLayer>{
+    return this._map.then((map: mapTypes.GoogleMap) => {
+      let transitLayer: mapTypes.TransitLayer = new google.maps.TransitLayer();
+      transitLayer.setMap(options.inVisible ? null : map);
+      return transitLayer;
     });
   }
 

--- a/packages/core/services/google-maps-types.ts
+++ b/packages/core/services/google-maps-types.ts
@@ -442,7 +442,7 @@ export interface TransitLayer extends MVCObject {
 }
 
 export interface TransitLayerOptions {
-  inVisible: boolean;
+  visible: boolean;
 }
 
 export interface Data extends MVCObject {

--- a/packages/core/services/google-maps-types.ts
+++ b/packages/core/services/google-maps-types.ts
@@ -435,6 +435,16 @@ export interface KmlMouseEvent extends MouseEvent {
   pixelOffset: Size;
 }
 
+export interface TransitLayer extends MVCObject {
+  getMap(): GoogleMap;
+  setMap(map: GoogleMap): void;
+  setOptions(options: TransitLayerOptions): void;
+}
+
+export interface TransitLayerOptions {
+  inVisible: boolean;
+}
+
 export interface Data extends MVCObject {
   features: Feature[];
   addGeoJson(geoJson: Object, options?: GeoJsonOptions): Feature[];

--- a/packages/core/services/managers/transit-layer-manager.spec.ts
+++ b/packages/core/services/managers/transit-layer-manager.spec.ts
@@ -1,0 +1,98 @@
+import {NgZone} from '@angular/core';
+import {TestBed, inject, fakeAsync, async } from '@angular/core/testing';
+import {AgmTransitLayer} from '../../directives/transit-layer';
+import {GoogleMapsAPIWrapper} from '../../services/google-maps-api-wrapper';
+import {TransitLayerManager} from '../../services/managers/transit-layer-manager';
+
+describe('TransitLayerManager', () => {
+    beforeAll(() => {
+        (<any>window).google = {
+            maps: {
+                TransitLayer: class TransitLayer {
+                    setMap = jest.fn();
+
+                    constructor() {
+
+                    }
+                },
+            }
+        };
+    });
+
+    beforeEach(() => {
+
+        TestBed.configureTestingModule({
+            providers: [
+                {provide: NgZone, useFactory: () => new NgZone({enableLongStackTrace: true})},
+                {
+                    provide: GoogleMapsAPIWrapper,
+                    useValue: {
+                        getNativeMap: () => Promise.resolve(),
+                        createTransitLayer: jest.fn()
+                    }
+                },
+                TransitLayerManager,
+
+            ]
+        });
+    }); // end beforeEach
+
+    describe('Create a new TransitLayer', () => {
+
+        it('should call mapsApiWrapper when creating a new transit',
+            fakeAsync(inject(
+                [TransitLayerManager, GoogleMapsAPIWrapper],
+                (transitLayerManager: TransitLayerManager, apiWrapper: GoogleMapsAPIWrapper) => {
+                    const newTransitLayer = new AgmTransitLayer(transitLayerManager);
+                    const opt = {inVisible: false};
+                    const spy = jest.spyOn(apiWrapper, 'createTransitLayer');
+                    transitLayerManager.addTransitLayer(newTransitLayer, opt);
+                    expect(spy).toHaveBeenCalled();
+
+                    spy.mockRestore();
+
+                })
+            )
+        );
+    });
+
+    describe('Toggling visibility of TransitLayer', () => {
+
+        it('should update that rectangle via setOptions method when the options changes', async(
+
+            inject(
+                [TransitLayerManager, GoogleMapsAPIWrapper],
+                (transitLayerManager: TransitLayerManager,
+                 apiWrapper: GoogleMapsAPIWrapper) => {
+                    const newTransitLayer = new AgmTransitLayer(transitLayerManager);
+                    newTransitLayer.inVisible = true;
+
+                    const transitLayerInstance: any = {
+                        setMap: jest.fn(),
+                        toggleTransitLayer: jest.fn(),
+                        setOptions: jest.fn()
+
+                    };
+
+                    (<jest.Mock>apiWrapper.createTransitLayer).mockReturnValue(
+                        Promise.resolve(transitLayerInstance)
+                    );
+
+                    transitLayerManager.addTransitLayer(newTransitLayer, {inVisible: false});
+                    expect(apiWrapper.createTransitLayer).toHaveBeenCalledWith({
+                        inVisible: false
+                    });
+
+                    newTransitLayer.inVisible = false;
+                    transitLayerManager.setOptions(newTransitLayer, {inVisible: true}).then(() => {
+                        expect(transitLayerInstance.setMap).toHaveBeenCalledWith(null);
+                    });
+
+                }
+            )
+
+        ));
+
+    });
+
+});

--- a/packages/core/services/managers/transit-layer-manager.spec.ts
+++ b/packages/core/services/managers/transit-layer-manager.spec.ts
@@ -1,5 +1,5 @@
 import {NgZone} from '@angular/core';
-import {TestBed, inject, fakeAsync, async } from '@angular/core/testing';
+import {TestBed, inject, fakeAsync} from '@angular/core/testing';
 import {AgmTransitLayer} from '../../directives/transit-layer';
 import {GoogleMapsAPIWrapper} from '../../services/google-maps-api-wrapper';
 import {TransitLayerManager} from '../../services/managers/transit-layer-manager';
@@ -44,12 +44,9 @@ describe('TransitLayerManager', () => {
                 [TransitLayerManager, GoogleMapsAPIWrapper],
                 (transitLayerManager: TransitLayerManager, apiWrapper: GoogleMapsAPIWrapper) => {
                     const newTransitLayer = new AgmTransitLayer(transitLayerManager);
-                    const opt = {inVisible: false};
-                    const spy = jest.spyOn(apiWrapper, 'createTransitLayer');
+                    const opt = {visible: false};
                     transitLayerManager.addTransitLayer(newTransitLayer, opt);
-                    expect(spy).toHaveBeenCalled();
-
-                    spy.mockRestore();
+                    expect(apiWrapper.createTransitLayer).toHaveBeenCalled();
 
                 })
             )
@@ -58,18 +55,17 @@ describe('TransitLayerManager', () => {
 
     describe('Toggling visibility of TransitLayer', () => {
 
-        it('should update that rectangle via setOptions method when the options changes', async(
+        it('should update that transit layer via setOptions method when the options changes', fakeAsync(
 
             inject(
                 [TransitLayerManager, GoogleMapsAPIWrapper],
                 (transitLayerManager: TransitLayerManager,
                  apiWrapper: GoogleMapsAPIWrapper) => {
                     const newTransitLayer = new AgmTransitLayer(transitLayerManager);
-                    newTransitLayer.inVisible = true;
+                    newTransitLayer.visible = true;
 
                     const transitLayerInstance: any = {
                         setMap: jest.fn(),
-                        toggleTransitLayer: jest.fn(),
                         setOptions: jest.fn()
 
                     };
@@ -78,13 +74,13 @@ describe('TransitLayerManager', () => {
                         Promise.resolve(transitLayerInstance)
                     );
 
-                    transitLayerManager.addTransitLayer(newTransitLayer, {inVisible: false});
+                    transitLayerManager.addTransitLayer(newTransitLayer, {visible: true});
                     expect(apiWrapper.createTransitLayer).toHaveBeenCalledWith({
-                        inVisible: false
+                        visible: true
                     });
 
-                    newTransitLayer.inVisible = false;
-                    transitLayerManager.setOptions(newTransitLayer, {inVisible: true}).then(() => {
+                    newTransitLayer.visible = false;
+                    transitLayerManager.setOptions(newTransitLayer, {visible: false}).then(() => {
                         expect(transitLayerInstance.setMap).toHaveBeenCalledWith(null);
                     });
 

--- a/packages/core/services/managers/transit-layer-manager.ts
+++ b/packages/core/services/managers/transit-layer-manager.ts
@@ -1,0 +1,70 @@
+import {Injectable} from '@angular/core';
+import {AgmTransitLayer} from '../../directives/transit-layer';
+import {GoogleMapsAPIWrapper} from '../google-maps-api-wrapper';
+import {TransitLayer, TransitLayerOptions, GoogleMap} from '../google-maps-types';
+
+declare var google: any;
+
+/**
+ * This class manages a Transit Layer for a Google Map instance.
+ */
+
+@Injectable()
+export class TransitLayerManager {
+    private _layers: Map<AgmTransitLayer, Promise<TransitLayer>> =
+        new Map<AgmTransitLayer, Promise<TransitLayer>>();
+
+    constructor(private _wrapper: GoogleMapsAPIWrapper) {}
+
+    /**
+     * Adds a transit layer to a map and local layer manager
+     * @param {AgmTransitLayer} layer - a transitLayer object
+     * @param {TransitLayerOptions} options - TransitLayerOptions options
+     * @returns void
+     */
+    addTransitLayer(layer: AgmTransitLayer, options: TransitLayerOptions): void {
+        const newLayer = this._wrapper.createTransitLayer(options);
+        this._layers.set(layer, newLayer);
+    }
+
+    /**
+     * Sets layer options
+     * @param {AgmTransitLayer} transitLayer object
+     * @param {options} TransitLayerOptions
+     * @returns Promise<void>
+     */
+    setOptions(layer: AgmTransitLayer, options: TransitLayerOptions): Promise<void> {
+        return this.toggleTransitLayer(layer, options);
+    }
+
+    /**
+     * Deletes a transit layer
+     * @param {AgmTransitLayer} layer - the transit layer to delete
+     * @returns  Promise<void>
+     */
+    deleteTransitLayer(layer: AgmTransitLayer): Promise<void> {
+        return this._layers.get(layer).then(currentLayer => {
+            currentLayer.setMap(null);
+            this._layers.delete(layer);
+        });
+    }
+
+    /**
+     * Hide/Show a Google Map transit layer
+     * @param {AgmTransitLayer} transitLayer object
+     * @param {options} TransitLayerOptions
+     * @returns Promise<void>
+     */
+    toggleTransitLayer(layer: AgmTransitLayer, options: TransitLayerOptions): Promise<void> {
+        return this._layers.get(layer).then(currentLayer => {
+            if (options.inVisible) {
+                currentLayer.setMap(null);
+                return Promise.resolve();
+            } else {
+               return this._wrapper.getNativeMap().then( (map: GoogleMap) => {
+                    currentLayer.setMap(map);
+                });
+            }
+        });
+    }
+}

--- a/packages/core/services/managers/transit-layer-manager.ts
+++ b/packages/core/services/managers/transit-layer-manager.ts
@@ -3,8 +3,6 @@ import {AgmTransitLayer} from '../../directives/transit-layer';
 import {GoogleMapsAPIWrapper} from '../google-maps-api-wrapper';
 import {TransitLayer, TransitLayerOptions, GoogleMap} from '../google-maps-types';
 
-declare var google: any;
-
 /**
  * This class manages a Transit Layer for a Google Map instance.
  */
@@ -34,7 +32,7 @@ export class TransitLayerManager {
      * @returns Promise<void>
      */
     setOptions(layer: AgmTransitLayer, options: TransitLayerOptions): Promise<void> {
-        return this.toggleTransitLayer(layer, options);
+        return this.toggleTransitLayerVisibility(layer, options);
     }
 
     /**
@@ -55,9 +53,9 @@ export class TransitLayerManager {
      * @param {options} TransitLayerOptions
      * @returns Promise<void>
      */
-    toggleTransitLayer(layer: AgmTransitLayer, options: TransitLayerOptions): Promise<void> {
+    toggleTransitLayerVisibility(layer: AgmTransitLayer, options: TransitLayerOptions): Promise<void> {
         return this._layers.get(layer).then(currentLayer => {
-            if (options.inVisible) {
+            if (!options.visible) {
                 currentLayer.setMap(null);
                 return Promise.resolve();
             } else {


### PR DESCRIPTION
- Added new Directive called <agm-transit-layer>
- Added test

Note: general styles applied to the map may affect the transit layer:

Change the default color for transit layer
`{
    featureType: 'transit', 
    elementType: 'geometry',
    stylers: [{color: '#2f3948'}] 
}`

Hide labels of the transit layer on the map
`{
    featureType: 'transit',
    elementType: 'labels.icon',
    stylers: [{visibility: 'off'}] 
}`


Also note that transit information is not available in some locations. Visit https://developers.google.com/maps/documentation/javascript/trafficlayer#transit_layer for more info.