### PR TITLE
feat(AgmMap): Add tilesloaded event to AgmMap

### DIFF
--- a/packages/core/directives/map.ts
+++ b/packages/core/directives/map.ts
@@ -361,7 +361,7 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
   /**
    * This event is fired when the visible tiles have finished loading.
    */
-  @Output() tilesLoaded: EventEmitter<void> = new EventEmitter<any>();
+  @Output() tilesLoaded: EventEmitter<void> = new EventEmitter<void>();
 
   constructor(private _elem: ElementRef, private _mapsWrapper: GoogleMapsAPIWrapper, protected _fitBoundsService: FitBoundsService, private _zone: NgZone) {
   }
@@ -585,7 +585,8 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
 
   private _handleTilesLoadedEvent() {
     const s = this._mapsWrapper.subscribeToMapEvent<void>('tilesloaded').subscribe(
-      () => { this.tilesLoaded.emit(void 0); });
+      () => this.tilesLoaded.emit(void 0)
+    );
     this._observableSubscriptions.push(s);
   }
 

--- a/packages/core/directives/map.ts
+++ b/packages/core/directives/map.ts
@@ -358,6 +358,11 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
    */
   @Output() mapReady: EventEmitter<any> = new EventEmitter<any>();
 
+  /**
+   * This event is fired when the visible tiles have finished loading.
+   */
+  @Output() tilesLoaded: EventEmitter<void> = new EventEmitter<any>();
+
   constructor(private _elem: ElementRef, private _mapsWrapper: GoogleMapsAPIWrapper, protected _fitBoundsService: FitBoundsService, private _zone: NgZone) {
   }
 
@@ -413,6 +418,7 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
     this._handleMapMouseEvents();
     this._handleBoundsChange();
     this._handleMapTypeIdChange();
+    this._handleTilesLoadedEvent();
     this._handleIdleEvent();
   }
 
@@ -574,6 +580,12 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
   private _handleIdleEvent() {
     const s = this._mapsWrapper.subscribeToMapEvent<void>('idle').subscribe(
       () => { this.idle.emit(void 0); });
+    this._observableSubscriptions.push(s);
+  }
+
+  private _handleTilesLoadedEvent() {
+    const s = this._mapsWrapper.subscribeToMapEvent<void>('tilesloaded').subscribe(
+      () => { this.tilesLoaded.emit(void 0); });
     this._observableSubscriptions.push(s);
   }
 


### PR DESCRIPTION
This pull request exposes 'tilesloaded' event on AgmMap component. GoogleMaps API reference [here](https://developers.google.com/maps/documentation/javascript/reference/map#Map.tilesloaded).
Closes #1701