### PR TITLE
fix(FitBounds): remove old location on loc change

### DIFF
--- a/packages/core/directives/fit-bounds.ts
+++ b/packages/core/directives/fit-bounds.ts
@@ -3,7 +3,6 @@ import { Subscription, Subject } from 'rxjs';
 import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 
 import { FitBoundsService, FitBoundsAccessor, FitBoundsDetails } from '../services/fit-bounds';
-import { LatLng, LatLngLiteral } from '../services/google-maps-types';
 
 /**
  * Adds the given directive to the auto fit bounds feature when the value is true.
@@ -53,17 +52,29 @@ export class AgmFitBounds implements OnInit, OnDestroy, OnChanges {
       .subscribe(details => this._updateBounds(details));
   }
 
+  /*
+   Either the location changed, or visible status changed.
+   Possible state changes are
+   invisible -> visible
+   visible -> invisible
+   visible -> visible (new location)
+  */
   private _updateBounds(newFitBoundsDetails?: FitBoundsDetails) {
+    // either visibility will change, or location, so remove the old one anyway
+    if (this._latestFitBoundsDetails) {
+      this._fitBoundsService.removeFromBounds(this._latestFitBoundsDetails.latLng);
+      // don't set latestFitBoundsDetails to null, because we can toggle visibility from
+      // true -> false -> true, in which case we still need old value cached here
+    }
+
     if (newFitBoundsDetails) {
       this._latestFitBoundsDetails = newFitBoundsDetails;
     }
     if (!this._latestFitBoundsDetails) {
       return;
     }
-    if (this.agmFitBounds) {
+    if (this.agmFitBounds === true) {
       this._fitBoundsService.addToBounds(this._latestFitBoundsDetails.latLng);
-    } else {
-      this._fitBoundsService.removeFromBounds(this._latestFitBoundsDetails.latLng);
     }
   }
 


### PR DESCRIPTION
when a FitBoundsAccessor emits new bounds,  remove the old ones from
the map's bounds array

fixes: #1512