### PR TITLE
fix: add map-types exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agm/_dev",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Angular components for Google Maps",
   "repository": {
     "type": "git",

--- a/packages/core/directives/marker.ts
+++ b/packages/core/directives/marker.ts
@@ -1,6 +1,6 @@
 import { AfterContentInit, ContentChildren, Directive, EventEmitter, forwardRef, Input, OnChanges, OnDestroy, Output, QueryList, SimpleChange } from '@angular/core';
 import { Observable, ReplaySubject, Subscription } from 'rxjs';
-import { MarkerLabel, MouseEvent } from '../map-types';
+import { MouseEvent } from '../map-types';
 import { FitBoundsAccessor, FitBoundsDetails } from '../services/fit-bounds';
 import * as mapTypes from '../services/google-maps-types';
 import { MarkerManager } from '../services/managers/marker-manager';
@@ -61,7 +61,7 @@ export class AgmMarker implements OnDestroy, OnChanges, AfterContentInit, FitBou
   /**
    * The label (a single uppercase character) for the marker.
    */
-  @Input() label: string | MarkerLabel;
+  @Input() label: string | mapTypes.MarkerLabel;
 
   /**
    * If true, the marker can be dragged. Default value is false.

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -3,9 +3,6 @@ export * from './directives';
 export * from './services';
 export * from './map-types';
 
-// Google Maps types
-export { LatLngBounds, LatLng, LatLngLiteral, MapTypeStyle, Padding, PolyMouseEvent } from './services/google-maps-types';
-
 // core module
 // we explicitly export the module here to prevent this Ionic 2 bug:
 // http://stevemichelotti.com/integrate-angular-2-google-maps-into-ionic-2/

--- a/packages/core/map-types.ts
+++ b/packages/core/map-types.ts
@@ -9,6 +9,21 @@ export {
   LatLngLiteral,
   PolyMouseEvent,
   MarkerLabel,
+  LatLng,
+  MapTypeStyle,
+  Padding,
+  ControlPosition,
+  OverviewMapControlOptions,
+  PanControlOptions,
+  RotateControlOptions,
+  MapTypeControlOptions,
+  MapTypeId,
+  ScaleControlOptions,
+  ScaleControlStyle,
+  StreetViewControlOptions,
+  ZoomControlOptions,
+  ZoomControlStyle,
+  FullscreenControlOptions,
 } from './services/google-maps-types';
 
 /**


### PR DESCRIPTION
leave only one level of barrel imports to fix known library problems

fixes: #1729 