### PR TITLE
fix: contains can accept LatLngLiteral

### DIFF
--- a/packages/core/map-types.ts
+++ b/packages/core/map-types.ts
@@ -2,6 +2,7 @@ import { LatLngLiteral } from './services/google-maps-types';
 
 // exported map types
 export {
+  GoogleMap,
   KmlMouseEvent,
   DataMouseEvent,
   LatLngBounds,

--- a/packages/core/services/google-maps-types.ts
+++ b/packages/core/services/google-maps-types.ts
@@ -147,7 +147,7 @@ export interface RectangleOptions {
 }
 
 export interface LatLngBounds {
-  contains(latLng: LatLng): boolean;
+  contains(latLng: LatLng | LatLngLiteral): boolean;
   equals(other: LatLngBounds | LatLngBoundsLiteral): boolean;
   extend(point: LatLng | LatLngLiteral): void;
   getCenter(): LatLng;

--- a/packages/js-marker-clusterer/package.json
+++ b/packages/js-marker-clusterer/package.json
@@ -12,7 +12,7 @@
   ],
   "peerDependencies": {
     "@angular/core": "^6.0.0 || ^7.0.0 || ^8.0.0",
-    "@agm/core": "^1.0.0-beta.7",
+    "@agm/core": "^1.0.0",
     "js-marker-clusterer": "^1.0.0"
   },
   "ngPackage": {

--- a/packages/snazzy-info-window/package.json
+++ b/packages/snazzy-info-window/package.json
@@ -13,7 +13,7 @@
   ],
   "peerDependencies": {
     "@angular/core": "^6.0.0 || ^7.0.0 || ^8.0.0",
-    "@agm/core": "^1.0.0-beta.7",
+    "@agm/core": "^1.0.0",
     "snazzy-info-window": "^1.1.0"
   },
   "ngPackage": {


### PR DESCRIPTION
 - LatLngBounds.contains method can accept either a LatLng or a
LatLngLiteral
 - make non-core modules depend on core version 1.0.0, not beta
 - add GoogleMap to default exports

fixes: #862