### PR TITLE
Update map.ts

### DIFF
--- a/packages/core/directives/map.ts
+++ b/packages/core/directives/map.ts
@@ -506,7 +506,13 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
       this._fitBounds();
       return;
     }
-
+    
+    if (typeof this.latitude === 'string') {
+      this.latitude = Number(this.latitude);
+    }
+    if (typeof this.longitude === 'string') {
+      this.longitude = Number(this.longitude);
+    }
     if (typeof this.latitude !== 'number' || typeof this.longitude !== 'number') {
       return;
     }


### PR DESCRIPTION
Update map latitude or longitude by string variable doesn't center it. But for markers are parsing input string to a number. I Copied code from Marker.ts file to update this map.ts for auto parsing string to number