### PR TITLE
unsubscribing fitBoundsSubscription when necessary

### DIFF
--- a/packages/core/directives/map.ts
+++ b/packages/core/directives/map.ts
@@ -536,6 +536,9 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
         }
         break;
       default:
+        if (this._fitBoundsSubscription) {
+          this._fitBoundsSubscription.unsubscribe();
+        }
         this._updateBounds(this.fitBounds, this.fitBoundsPadding);
     }
   }


### PR DESCRIPTION
If the fitBounds are not automatically computed, unsubscription from existing fitBoundsSubscription should follow.

Fixing an edge case problem where if user was using automatic fitBounds calculation suddenly switches to fitBounds object (e.g. LngLatBoundsLiteral) and then provided fitBounds by user would be overwritten by the active subscription.

This is quick fix.