### PR TITLE
fix: eager promise creation to avoid NPE

### DIFF
--- a/packages/core/src/lib/directives/map.ts
+++ b/packages/core/src/lib/directives/map.ts
@@ -681,10 +681,7 @@ export class AgmMap implements OnChanges, AfterContentInit, OnDestroy {
       streetViewControl: !this.disableDefaultUI,
       zoomControl: !this.disableDefaultUI,
     };
-
-    this._mapsWrapper.getNativeMap().then(() => {
-      this.mapControls.forEach(control => Object.assign(controlOptions, control.getOptions()));
-      this._mapsWrapper.setMapOptions(controlOptions);
-    });
+    this.mapControls.forEach(control => Object.assign(controlOptions, control.getOptions()));
+    this._mapsWrapper.setMapOptions(controlOptions);
   }
 }

--- a/packages/core/src/lib/services/managers/circle-manager.ts
+++ b/packages/core/src/lib/services/managers/circle-manager.ts
@@ -13,8 +13,8 @@ export class CircleManager {
   constructor(private _apiWrapper: GoogleMapsAPIWrapper, private _zone: NgZone) {}
 
   addCircle(circle: AgmCircle) {
-    this._apiWrapper.getNativeMap().then( () =>
-      this._circles.set(circle, this._apiWrapper.createCircle({
+    this._circles.set(circle, this._apiWrapper.getNativeMap().then( () =>
+      this._apiWrapper.createCircle({
         center: {lat: circle.latitude, lng: circle.longitude},
         clickable: circle.clickable,
         draggable: circle.draggable,

--- a/packages/core/src/lib/services/managers/rectangle-manager.ts
+++ b/packages/core/src/lib/services/managers/rectangle-manager.ts
@@ -13,8 +13,8 @@ export class RectangleManager {
   constructor(private _apiWrapper: GoogleMapsAPIWrapper, private _zone: NgZone) {}
 
   addRectangle(rectangle: AgmRectangle) {
-    this._apiWrapper.getNativeMap().then(() =>
-      this._rectangles.set(rectangle, this._apiWrapper.createRectangle({
+    this._rectangles.set(rectangle, this._apiWrapper.getNativeMap().then( () =>
+      this._apiWrapper.createRectangle({
         bounds: {
           north: rectangle.north,
           east: rectangle.east,


### PR DESCRIPTION
manager classes ran getNativeMap to call wrapper class which itself
waited for map to be ready. Change to create an unresolved promise
immediately

fixes: #1855
fixed #1857