### PR TITLE
Support for Cloud-based map styling

### DIFF
--- a/packages/core/src/lib/directives/map.ts
+++ b/packages/core/src/lib/directives/map.ts
@@ -195,6 +195,11 @@ export class AgmMap implements OnChanges, AfterContentInit, OnDestroy {
    * The latitude that defines the center of the map.
    */
   @Input() latitude = 0;
+  
+  /**
+   * The mapID to be used for the map.
+   */
+  @Input() mapId = "";
 
   /**
    * The zoom level of the map. The default zoom level is 8.
@@ -434,6 +439,7 @@ export class AgmMap implements OnChanges, AfterContentInit, OnDestroy {
 
   private _initMapInstance(el: HTMLElement) {
     this._mapsWrapper.createMap(el, {
+      mapId: this.mapId,
       center: {lat: this.latitude || 0, lng: this.longitude || 0},
       zoom: this.zoom,
       minZoom: this.minZoom,

--- a/packages/core/src/lib/services/maps-api-loader/lazy-maps-api-loader.ts
+++ b/packages/core/src/lib/services/maps-api-loader/lazy-maps-api-loader.ts
@@ -27,6 +27,11 @@ export interface LazyMapsAPILoaderConfigLiteral {
   apiKey?: string;
 
   /**
+   * Defines which Google Maps Map IDs (map_ids) (see: https://developers.google.com/maps/documentation/javascript/cloud-based-map-styling)
+   */
+  mapIds?: string[];
+  
+  /**
    * The Google Maps client ID (for premium plans).
    * When you have a Google Maps APIs Premium Plan license, you must authenticate
    * your application with either an API key or a client ID.
@@ -158,6 +163,7 @@ export class LazyMapsAPILoader extends MapsAPILoader {
       v: this._config.apiVersion || 'quarterly',
       callback: callbackName,
       key: this._config.apiKey,
+      'map_ids': this._config.mapIds,
       client: this._config.clientId,
       channel: this._config.channel,
       libraries: this._config.libraries,


### PR DESCRIPTION
Add the map_ids script param and mapId map option to be compatible with the Cloud-based styling beta feature https://developers.google.com/maps/documentation/javascript/cloud-based-map-styling