### PR TITLE
Markerclusterer: Handle mouseover and mouseout events

### DIFF
--- a/packages/markerclusterer/src/lib/directives/marker-cluster.ts
+++ b/packages/markerclusterer/src/lib/directives/marker-cluster.ts
@@ -6,6 +6,7 @@ import { InfoWindowManager, MarkerManager } from '@agm/core';
 import { ClusterIconStyle, MarkerClustererOptions } from '@google/markerclustererplus';
 import { Calculator } from '@google/markerclustererplus/dist/markerclusterer';
 import { ClusterManager } from '../services/managers/cluster-manager';
+import { Cluster } from '@google/markerclustererplus/dist/cluster';
 
 // tslint:disable: jsdoc-format
 /**
@@ -134,6 +135,8 @@ export class AgmMarkerCluster implements OnDestroy, OnChanges, OnInit, MarkerClu
   @Input() title: string;
 
   @Output() clusterClick: EventEmitter<void> = new EventEmitter<void>();
+  @Output() mouseOver: EventEmitter<Cluster> = new EventEmitter<Cluster>();
+  @Output() mouseOut: EventEmitter<Cluster> = new EventEmitter<Cluster>();
 
   private _observableSubscriptions: Subscription[] = [];
 
@@ -200,6 +203,14 @@ export class AgmMarkerCluster implements OnDestroy, OnChanges, OnInit, MarkerClu
         name: 'clusterclick',
         handler: () => this.clusterClick.emit(),
       },
+      {
+        name: 'mouseover',
+        handler: (cluster) => this.mouseOver.emit(cluster),
+      },
+      {
+        name: 'mouseout',
+        handler: (cluster) => this.mouseOut.emit(cluster),
+      }
     ];
     handlers.forEach((obj) => {
       const os = this._clusterManager.createClusterEventObservable(obj.name).subscribe(obj.handler);


### PR DESCRIPTION
This PR adds support for handling mouseover and mouseout events emitted by clusters on the map.